### PR TITLE
Update http api client

### DIFF
--- a/src/conductor/client/http/api_client.py
+++ b/src/conductor/client/http/api_client.py
@@ -70,18 +70,6 @@ class ApiClient(object):
         self.pool.close()
         self.pool.join()
 
-    @property
-    def user_agent(self):
-        """User agent for this API client"""
-        return self.default_headers['User-Agent']
-
-    @user_agent.setter
-    def user_agent(self, value):
-        self.default_headers['User-Agent'] = value
-
-    def set_default_header(self, header_name, header_value):
-        self.default_headers[header_name] = header_value
-
     def __call_api(
             self, resource_path, method, path_params=None,
             query_params=None, header_params=None, body=None, post_params=None,

--- a/src/conductor/client/http/api_client.py
+++ b/src/conductor/client/http/api_client.py
@@ -60,7 +60,9 @@ class ApiClient(object):
 
         self.pool = ThreadPool()
         self.rest_client = rest.RESTClientObject(configuration)
-        self.default_headers = {}
+        self.default_headers = {
+            'Accept-Encoding': 'gzip',
+        }
         if header_name is not None:
             self.default_headers[header_name] = header_value
         self.cookie = cookie


### PR DESCRIPTION
Changes:
- Removed unused methods from HTTP API client
- Added `gzip` encoding for all requests sent to Conductor server

Tests:
- Received header at response from server that supports `gzip`:
  - `header: Content-Encoding: gzip`
- Same behavior with server without `gzip` support