### PR TITLE
Allow using basic auth URL

### DIFF
--- a/src/conductor/client/http/api_client.py
+++ b/src/conductor/client/http/api_client.py
@@ -12,6 +12,7 @@ import re
 import six
 import tempfile
 import traceback
+import urllib3
 
 logger = logging.getLogger(
     Configuration.get_logging_formatted_name(
@@ -65,6 +66,13 @@ class ApiClient(object):
         }
         if header_name is not None:
             self.default_headers[header_name] = header_value
+
+        parsed = urllib3.util.parse_url(self.configuration.host)
+        if parsed.auth is not None:
+            self.default_headers.update(
+                urllib3.util.make_headers(basic_auth=parsed.auth)
+            )
+
         self.cookie = cookie
         self.__refresh_auth_token()
 

--- a/src/conductor/client/http/api_client.py
+++ b/src/conductor/client/http/api_client.py
@@ -2,6 +2,7 @@ from conductor.client.configuration.configuration import Configuration
 from conductor.client.http import rest
 from multiprocessing.pool import ThreadPool
 from six.moves.urllib.parse import quote
+from typing import Dict
 import conductor.client.http.models as http_models
 import datetime
 import json
@@ -53,25 +54,23 @@ class ApiClient(object):
         'object': object,
     }
 
-    def __init__(self, configuration=None, header_name=None, header_value=None,
-                 cookie=None):
+    def __init__(
+            self,
+            configuration=None,
+            header_name=None,
+            header_value=None,
+            cookie=None
+    ):
         if configuration is None:
             configuration = Configuration()
         self.configuration = configuration
 
         self.pool = ThreadPool()
         self.rest_client = rest.RESTClientObject(configuration)
-        self.default_headers = {
-            'Accept-Encoding': 'gzip',
-        }
-        if header_name is not None:
-            self.default_headers[header_name] = header_value
 
-        parsed = urllib3.util.parse_url(self.configuration.host)
-        if parsed.auth is not None:
-            self.default_headers.update(
-                urllib3.util.make_headers(basic_auth=parsed.auth)
-            )
+        self.default_headers = self.__get_default_headers(
+            header_name, header_value
+        )
 
         self.cookie = cookie
         self.__refresh_auth_token()
@@ -660,3 +659,18 @@ class ApiClient(object):
                 f'Failed to get new token, reason: {traceback.format_exc()}'
             )
             return None
+
+    def __get_default_headers(self, header_name: str, header_value: object) -> Dict[str, object]:
+        headers = {
+            'Accept-Encoding': 'gzip',
+        }
+        if header_name is not None:
+            headers[header_name] = header_value
+        parsed = urllib3.util.parse_url(self.configuration.host)
+        if parsed.auth is not None:
+            encrypted_headers = urllib3.util.make_headers(
+                basic_auth=parsed.auth
+            )
+            for key, value in encrypted_headers.items():
+                headers[key] = value
+        return headers

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -5,18 +5,26 @@ from integration.test_workflow_definition import run_workflow_definition_tests
 from integration.test_workflow_execution import run_workflow_execution_tests
 import os
 
-KEY_ID = os.getenv('PYTHON_INTEGRATION_TESTS_SERVER_KEY_ID')
-KEY_SECRET = os.getenv('PYTHON_INTEGRATION_TESTS_SERVER_KEY_SECRET')
-SERVER_API_URL = os.getenv('PYTHON_INTEGRATION_TESTS_SERVER_API_URL')
+ENV = {
+    'KEY': 'PYTHON_INTEGRATION_TESTS_SERVER_KEY_ID',
+    'SECRET': 'PYTHON_INTEGRATION_TESTS_SERVER_KEY_SECRET',
+    'URL': 'PYTHON_INTEGRATION_TESTS_SERVER_API_URL',
+}
 
 
 def generate_configuration():
+    envs = {}
+    for key, env in ENV.items():
+        value = os.getenv(env)
+        if value is None or value == '':
+            raise Exception(f'ENV not set - {env}')
+        envs[key] = value
     return Configuration(
-        server_api_url=SERVER_API_URL,
+        server_api_url=envs['URL'],
         debug=True,
         authentication_settings=AuthenticationSettings(
-            key_id=KEY_ID,
-            key_secret=KEY_SECRET,
+            key_id=envs['KEY'],
+            key_secret=envs['SECRET'],
         )
     )
 

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,8 +1,7 @@
-import base64
-import unittest
-
 from conductor.client.configuration.configuration import Configuration
 from conductor.client.http.api_client import ApiClient
+import base64
+import unittest
 
 
 class TestConfiguration(unittest.TestCase):
@@ -36,8 +35,12 @@ class TestConfiguration(unittest.TestCase):
             server_api_url="https://user:password@play.orkes.io/api/"
         )
         basic_auth = "user:password"
-        self.assertEqual(configuration.host, f"https://{basic_auth}@play.orkes.io/api/")
-        token = "Basic " + base64.b64encode(bytes(basic_auth, "utf-8")).decode("utf-8")
+        expected_host = f"https://{basic_auth}@play.orkes.io/api/"
+        self.assertEqual(
+            configuration.host, expected_host,
+        )
+        token = "Basic " + \
+            base64.b64encode(bytes(basic_auth, "utf-8")).decode("utf-8")
         api_client = ApiClient(configuration)
         self.assertEqual(
             api_client.default_headers,

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,5 +1,8 @@
-from conductor.client.configuration.configuration import Configuration
+import base64
 import unittest
+
+from conductor.client.configuration.configuration import Configuration
+from conductor.client.http.api_client import ApiClient
 
 
 class TestConfiguration(unittest.TestCase):
@@ -26,4 +29,17 @@ class TestConfiguration(unittest.TestCase):
         self.assertEqual(
             configuration.host,
             'https://play.orkes.io/api/'
+        )
+
+    def test_initialization_with_basic_auth_server_api_url(self):
+        configuration = Configuration(
+            server_api_url="https://user:password@play.orkes.io/api/"
+        )
+        basic_auth = "user:password"
+        self.assertEqual(configuration.host, f"https://{basic_auth}@play.orkes.io/api/")
+        token = "Basic " + base64.b64encode(bytes(basic_auth, "utf-8")).decode("utf-8")
+        api_client = ApiClient(configuration)
+        self.assertEqual(
+            api_client.default_headers,
+            {"Accept-Encoding": "gzip", "authorization": token},
         )


### PR DESCRIPTION
This PR simplies replicates how module requests deals with authenticated URLs.

### How to test 

One option is to mege https://github.com/conductor-sdk/conductor-python/pull/118  and then rebase and run integration testes against a basic auth URL server. 
