### PR TITLE
Fixed issues related to CI GH workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Continuous Delivery
 
-on: release
+on:
+  release:
+    types: [published]
 
 jobs:
   build-package-and-publish-release-at-pypi:
@@ -32,6 +34,8 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: "3.x"
+      - name: Wait for package to be available at pypi
+        run: sleep 30
       - name: Install package from remote files
         run: python3 -m pip install conductor-python==$CONDUCTOR_PYTHON_VERSION
         env:


### PR DESCRIPTION
* Previously, many events were triggering CI workflow, trying to re-publish the same release
* Added a sleep for `30` seconds before attempting to validate the new release from `pypi`