### PR TITLE
Added support for paused workers

### DIFF
--- a/src/conductor/client/automator/task_runner.py
+++ b/src/conductor/client/automator/task_runner.py
@@ -52,6 +52,9 @@ class TaskRunner:
 
     def __poll_task(self) -> Task:
         task_definition_name = self.worker.get_task_definition_name()
+        if self.worker.paused():
+            logger.warning(f'Stop polling task for: {task_definition_name}')
+            return None
         if self.metrics_collector is not None:
             self.metrics_collector.increment_task_poll(
                 task_definition_name

--- a/src/conductor/client/worker/worker_interface.py
+++ b/src/conductor/client/worker/worker_interface.py
@@ -64,3 +64,9 @@ class WorkerInterface(abc.ABC):
         :return: str
         """
         return None
+
+    def paused(self) -> bool:
+        """
+        Override this method to pause the worker from polling.
+        """
+        return False


### PR DESCRIPTION
paused() interface give an opportunity to the worker/client to check whether to poll tasks to execute. #134 