### PR TITLE
:bug: Fixes no content response on task poll

### DIFF
--- a/src/conductor/client/http/api_client.py
+++ b/src/conductor/client/http/api_client.py
@@ -226,7 +226,7 @@ class ApiClient(object):
 
         :return: object.
         """
-        if data is b'' or data is None:
+        if not data:
             return None
 
         if type(klass) == str:


### PR DESCRIPTION
This PR fixes an unexpected behaviour when polling for tasks on an empty task queue observed with conductor-python version 1.0.56

In [ApiClient.deserialize](https://github.com/conductor-sdk/conductor-python/blob/8204fed72935ff92a320b19ef6d3ece604755ad7/src/conductor/client/http/api_client.py#L199) method, the following code is executed:
```
try:
    data = response.resp.json()
except Exception:
    data = response.resp.text
```
When there is no task to be fetched, the exception is raised and data variable will be an empty string `data = ''`. After that, [ApiClient.__deserialize](https://github.com/conductor-sdk/conductor-python/blob/8204fed72935ff92a320b19ef6d3ece604755ad7/src/conductor/client/http/api_client.py#L221) method is called, were this check is performed:
```
if data is b'' or data is None:
    return None
```
In this case, as `data` is an empty string, the if clause is False and an invalid task will be created generating errors in the workers.

This PR expands the analysis of the mentioned if clause and will return `None` for this case.