### PR TITLE
add logs to the task result

### DIFF
--- a/src/conductor/client/automator/task_runner.py
+++ b/src/conductor/client/automator/task_runner.py
@@ -4,6 +4,7 @@ from conductor.client.http.api_client import ApiClient
 from conductor.client.http.api.task_resource_api import TaskResourceApi
 from conductor.client.http.models.task import Task
 from conductor.client.http.models.task_result import TaskResult
+from conductor.client.http.models.task_exec_log import TaskExecLog
 from conductor.client.telemetry.metrics_collector import MetricsCollector
 from conductor.client.worker.worker_interface import WorkerInterface
 import logging
@@ -147,7 +148,8 @@ class TaskRunner:
             )
             task_result.status = 'FAILED'
             task_result.reason_for_incompletion = str(e)
-            logger.info(
+            task_result.logs = [TaskExecLog(traceback.format_exc(), task_result.task_id, int(time.time()))]
+            logger.error(
                 'Failed to execute task, id: {task_id}, workflow_instance_id: {workflow_instance_id}, task_definition_name: {task_definition_name}, reason: {reason}'.format(
                     task_id=task.task_id,
                     workflow_instance_id=task.workflow_instance_id,

--- a/tests/unit/test_task_runner.py
+++ b/tests/unit/test_task_runner.py
@@ -170,12 +170,6 @@ class TestTaskRunner(unittest.TestCase):
         spent_time = finish_time - start_time
         self.assertGreater(spent_time, expected_time)
 
-    def test_get_task_result_with_invalid_task(self):
-        expected_task_result = None
-        task_runner = self.__get_valid_task_runner()
-        task_result = task_runner._TaskRunner__get_task_result(None)
-        self.assertEqual(task_result, expected_task_result)
-
     def __get_valid_task_runner(self):
         return TaskRunner(
             configuration=Configuration(),

--- a/tests/unit/test_task_runner.py
+++ b/tests/unit/test_task_runner.py
@@ -6,7 +6,7 @@ from conductor.client.http.models.task_result import TaskResult
 from conductor.client.http.models.task_result_status import TaskResultStatus
 from tests.unit.resources.workers import ClassWorker
 from tests.unit.resources.workers import FaultyExecutionWorker
-from unittest.mock import patch
+from unittest.mock import patch, ANY
 import logging
 import time
 import unittest
@@ -94,7 +94,8 @@ class TestTaskRunner(unittest.TestCase):
             workflow_instance_id=self.WORKFLOW_INSTANCE_ID,
             worker_id=worker.get_identity(),
             status=TaskResultStatus.FAILED,
-            reason_for_incompletion='faulty execution'
+            reason_for_incompletion='faulty execution',
+            logs=ANY
         )
         task_runner = TaskRunner(
             configuration=Configuration(),
@@ -103,6 +104,7 @@ class TestTaskRunner(unittest.TestCase):
         task = self.__get_valid_task()
         task_result = task_runner._TaskRunner__execute_task(task)
         self.assertEqual(task_result, expected_task_result)
+        self.assertIsNotNone(task_result.logs)
 
     def test_execute_task(self):
         expected_task_result = self.__get_valid_task_result()
@@ -167,6 +169,12 @@ class TestTaskRunner(unittest.TestCase):
         finish_time = time.time()
         spent_time = finish_time - start_time
         self.assertGreater(spent_time, expected_time)
+
+    def test_get_task_result_with_invalid_task(self):
+        expected_task_result = None
+        task_runner = self.__get_valid_task_runner()
+        task_result = task_runner._TaskRunner__get_task_result(None)
+        self.assertEqual(task_result, expected_task_result)
 
     def __get_valid_task_runner(self):
         return TaskRunner(


### PR DESCRIPTION
Add logs to the task result and change the log message from info to error in case of an exception during the task execution.