### PR TITLE
Added fork join to rshift

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
 	requests >= 2.28.1
     typing-extensions >= 4.2.0
     astor >= 0.8.1
+    shortuuid >= 1.0.11
 
 [options.packages.find]
 where = src

--- a/src/conductor/client/workflow/task/fork_task.py
+++ b/src/conductor/client/workflow/task/fork_task.py
@@ -30,7 +30,6 @@ class ForkTask(TaskInterface):
                 )
             workflow_task.fork_tasks.append(converted_inner_forked_tasks)
             workflow_task.join_on.append(
-                get_join_task(
-                    converted_inner_forked_tasks[-1].task_reference_name)
+                converted_inner_forked_tasks[-1].task_reference_name
             )
         return workflow_task

--- a/tests/integration/metadata/test_workflow_definition.py
+++ b/tests/integration/metadata/test_workflow_definition.py
@@ -127,6 +127,12 @@ def generate_fork_task(workflow_executor: WorkflowExecutor) -> ForkTask:
         ]
     )
 
+def generate_join_task(workflow_executor: WorkflowExecutor, fork_task: ForkTask) -> JoinTask:
+    return JoinTask(
+        task_ref_name='join_forked',
+        join_on=fork_task.to_workflow_task().join_on
+    )
+
 
 def generate_sub_workflow_task() -> SubWorkflowTask:
     return SubWorkflowTask(
@@ -155,9 +161,9 @@ def generate_dynamic_fork_task() -> DynamicForkTask:
     )
 
 
-def generate_http_task() -> HttpTask:
+def generate_http_task(task_ref_name='http_task') -> HttpTask:
     return HttpTask(
-        'http_task', HttpInput(
+        task_ref_name, HttpInput(
             uri="https://orkes-api-tester.orkesconductor.com/get"
         ),
     )
@@ -189,19 +195,35 @@ def generate_sub_workflow(workflow_executor: WorkflowExecutor) -> ConductorWorkf
 
 
 def generate_workflow(workflow_executor: WorkflowExecutor) -> ConductorWorkflow:
+    fork_task = generate_fork_task(workflow_executor)
+    
     workflow = ConductorWorkflow(
         executor=workflow_executor,
         name='test-python-sdk-workflow-as-code',
         description='Python workflow example from code',
         version=1234,
     ).add(
-        generate_http_task()
+        generate_http_task("http_task_0")
     ).add(
         generate_simple_task(12)
     ).add(
         generate_set_variable_task()
     ).add(
-        generate_fork_task(workflow_executor)
+        fork_task
+    ).add(
+        generate_join_task(workflow_executor, fork_task)
     ).owner_email(WORKFLOW_OWNER_EMAIL)
+
     workflow >> generate_sub_workflow_task() >> generate_json_jq_task()
+
+    forked_task_1 = generate_http_task("http_task_1")
+    forked_task_2 = generate_http_task("http_task_2")
+    forked_task_31 = generate_http_task("http_task_31")
+    forked_task_32 = generate_http_task("http_task_32")
+    forked_task_41 = generate_http_task("http_task_41")
+    forked_task_42 = generate_http_task("http_task_42")
+
+    workflow >> [forked_task_1, forked_task_2]
+    workflow >> [[forked_task_31, forked_task_32], [forked_task_41, forked_task_42]]
+
     return workflow


### PR DESCRIPTION
Added support for fork join tasks using rshift >> operator.

E.g
```python
    uri = "https://orkes-api-tester.orkesconductor.com/get"

    forked_task_1 = HttpTask("http_task_1", HttpInput(uri))
    forked_task_2 = HttpTask("http_task_2", HttpInput(uri))
    forked_task_31 = HttpTask("http_task_31", HttpInput(uri))
    forked_task_32 = HttpTask("http_task_32", HttpInput(uri))
    forked_task_41 = HttpTask("http_task_41", HttpInput(uri))
    forked_task_42 = HttpTask("http_task_42", HttpInput(uri))

    // Forks two tasks
    workflow >> [forked_task_1, forked_task_2]
    // Forks two sequences of tasks
    workflow >> [[forked_task_31, forked_task_32], [forked_task_41, forked_task_42]]
   ```  