### PR TITLE
Fixed token error logging

### DIFF
--- a/src/conductor/client/automator/task_runner.py
+++ b/src/conductor/client/automator/task_runner.py
@@ -193,6 +193,16 @@ class TaskRunner:
                     )
                 )
                 return response
+            except ApiException as e:
+                if self.metrics_collector is not None:
+                    self.metrics_collector.increment_task_update_error(
+                        task_definition_name, type(e)
+                    )
+                logger.error(f'{task_definition_name} worker cannot connect to conductor API, status code: {e.status}, detail: {e.body}')
+                logger.debug(
+                    f'Failed to poll task for: {task_definition_name}, reason: {traceback.format_exc()}'
+                )
+                return None
             except Exception as e:
                 if self.metrics_collector is not None:
                     self.metrics_collector.increment_task_update_error(

--- a/src/conductor/client/automator/task_runner.py
+++ b/src/conductor/client/automator/task_runner.py
@@ -91,7 +91,7 @@ class TaskRunner:
                 self.metrics_collector.increment_task_poll_error(
                     task_definition_name, type(e)
                 )
-            logger.error(f'{task_definition_name} worker cannot connect to conductor API, status code: {e.status}, detail: {e.body}')
+            logger.info(f'{task_definition_name} worker cannot connect to conductor API, status code: {e.status}, detail: {e.body}')
             logger.debug(
                 f'Failed to poll task for: {task_definition_name}, reason: {traceback.format_exc()}'
             )
@@ -198,7 +198,7 @@ class TaskRunner:
                     self.metrics_collector.increment_task_update_error(
                         task_definition_name, type(e)
                     )
-                logger.error(f'{task_definition_name} worker cannot connect to conductor API, status code: {e.status}, detail: {e.body}')
+                logger.info(f'{task_definition_name} worker cannot connect to conductor API, status code: {e.status}, detail: {e.body}')
                 logger.debug(
                     f'Failed to poll task for: {task_definition_name}, reason: {traceback.format_exc()}'
                 )

--- a/tests/unit/test_task_runner.py
+++ b/tests/unit/test_task_runner.py
@@ -6,6 +6,7 @@ from conductor.client.http.models.task_result import TaskResult
 from conductor.client.http.models.task_result_status import TaskResultStatus
 from tests.unit.resources.workers import ClassWorker
 from tests.unit.resources.workers import FaultyExecutionWorker
+from conductor.client.http.rest import ApiException, RESTClientObject
 from unittest.mock import patch, ANY
 import logging
 import time
@@ -81,6 +82,16 @@ class TestTaskRunner(unittest.TestCase):
             task_runner = self.__get_valid_task_runner()
             task = task_runner._TaskRunner__poll_task()
             self.assertEqual(task, expected_task)
+
+    def test_poll_task_with_unauthorized_access(self):
+        with patch.object(
+            RESTClientObject,
+            'request',
+            side_effect=ApiException(status=401)
+        ):
+            task_runner = self.__get_valid_task_runner()
+            task = task_runner._TaskRunner__poll_task()
+            self.assertIsNone(task)
 
     def test_execute_task_with_invalid_task(self):
         task_runner = self.__get_valid_task_runner()


### PR DESCRIPTION
Improved error logging when wrong API credentials are provided. 

Before change: Previously in order to see the error, `debug=True` had to be set and that spewed the whole stack trace. With debug=False, nothing was printed so user didn't know what was the issue.

After change: Now, `debug=True` is not necessary and it returns a more readable message extracted out from the HTTP response.
```
conductor.client.automator.task_runner ERROR    
python_annotated_task worker cannot connect to conductor API,
 status code: 401,
 detail: {"message":"Token cannot be null or empty","error":"INVALID_TOKEN","timestamp":1693530615110}
```