### PR TITLE
Add missing import for easier onboarding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ python3 -m pip install conductor-python
 Everything related to server settings should be done within the `Configuration` class by setting the required parameter (when initializing an object) like this:
 
 ```python
+from conductor.client.configuration.configuration import Configuration
+
 configuration = Configuration(
     server_api_url='https://play.orkes.io/api',
     debug=True


### PR DESCRIPTION
Was fairly annoying to track down the right imports for getting at minimal configuration setup in a fast onboarding manner - simply adding the import to cleanup onboarding for folks.