### PR TITLE
Allow sharing task definitions amongst a worker process in order to conserve memory

### DIFF
--- a/src/conductor/client/worker/worker.py
+++ b/src/conductor/client/worker/worker.py
@@ -30,13 +30,13 @@ def is_callable_return_value_of_type(callable: ExecuteTaskFunction, object_type:
 
 class Worker(WorkerInterface):
     def __init__(self,
-                 task_definition_name: str,
+                 task_definition_names: str,
                  execute_function: ExecuteTaskFunction,
                  poll_interval: float = None,
                  domain: str = None,
                  worker_id: str = None,
                  ) -> Self:
-        super().__init__(task_definition_name)
+        super().__init__(task_definition_names)
         if poll_interval == None:
             self.poll_interval = deepcopy(
                 super().get_polling_interval_in_seconds())

--- a/src/conductor/client/worker/worker_interface.py
+++ b/src/conductor/client/worker/worker_interface.py
@@ -2,11 +2,13 @@ from conductor.client.http.models.task import Task
 from conductor.client.http.models.task_result import TaskResult
 import abc
 import socket
+from typing import Union, List
 
 
 class WorkerInterface(abc.ABC):
-    def __init__(self, task_definition_name: str):
-        self.task_definition_name = task_definition_name
+    def __init__(self, task_definition_names: Union[str, list]):
+        self.task_definition_names = task_definition_names
+        self.next_task_index = 0
 
     @abc.abstractmethod
     def execute(self, task: Task) -> TaskResult:
@@ -42,7 +44,16 @@ class WorkerInterface(abc.ABC):
 
         :return: TaskResult
         """
-        return self.task_definition_name
+        if isinstance(self.task_definition_names, list):
+            if self.next_task_index >= len(self.task_definition_names):
+                self.next_task_index = 0
+            task_definition_name = self.task_definition_names[self.next_task_index]
+            if self.next_task_index == (len(self.task_definition_names) - 1):
+                self.next_task_index = 0
+            else:
+                self.next_task_index += 1
+            return task_definition_name
+        return self.task_definition_names
 
     def get_task_result_from_task(self, task: Task) -> TaskResult:
         """


### PR DESCRIPTION
Running an example worker set of tasks on a large Django monolith today:
<img width="1056" alt="image" src="https://github.com/conductor-sdk/conductor-python/assets/479892/fc110c2c-95da-4065-81f6-f9ab080d91e8">

Running the same worker tasks with this optimization:
<img width="968" alt="image" src="https://github.com/conductor-sdk/conductor-python/assets/479892/f34d6cf3-ba80-44f2-8c6c-4a05bffafd3e">

