### PR TITLE
Fix DoWhileTask/LoopTask with several subtasks

### DIFF
--- a/src/conductor/client/workflow/task/do_while_task.py
+++ b/src/conductor/client/workflow/task/do_while_task.py
@@ -18,13 +18,16 @@ class DoWhileTask(TaskInterface):
             task_type=TaskType.DO_WHILE,
         )
         self._loop_condition = deepcopy(termination_condition)
-        self._loop_over = deepcopy(tasks)
+        if isinstance(tasks, List):
+            self._loop_over = deepcopy(tasks)
+        else:
+            self._loop_over = [deepcopy(tasks)]
 
     def to_workflow_task(self) -> WorkflowTask:
         workflow = super().to_workflow_task()
         workflow.loop_condition = self._loop_condition
         workflow.loop_over = get_task_interface_list_as_workflow_task_list(
-            self._loop_over,
+            *self._loop_over,
         )
         return workflow
 

--- a/tests/integration/metadata/test_workflow_definition.py
+++ b/tests/integration/metadata/test_workflow_definition.py
@@ -116,6 +116,12 @@ def generate_do_while_task() -> LoopTask:
         tasks=generate_switch_task(),
     )
 
+def generate_do_while_task_multiple() -> LoopTask:
+    return LoopTask(
+        task_ref_name="loop_until_success_multiple",
+        iterations=1,
+        tasks=[generate_simple_task(i) for i in range(13, 14)],
+    )
 
 def generate_fork_task(workflow_executor: WorkflowExecutor) -> ForkTask:
     return ForkTask(
@@ -123,6 +129,7 @@ def generate_fork_task(workflow_executor: WorkflowExecutor) -> ForkTask:
         forked_tasks=[
             [
                 generate_do_while_task(),
+                generate_do_while_task_multiple(),
                 generate_sub_workflow_inline_task(workflow_executor)
             ],
             [generate_simple_task(i) for i in range(3, 5)]


### PR DESCRIPTION
Hello,

An exception is raised when adding a DoWhileTask or a LoopTask that contains a list of `tasks` to a workflow.

```python
workflow = ConductorWorkflow(...)
task1 = SimpleTask(...)
task2 = SimpleTask(...)

dowhile_single = DoWhileTask(
    task_ref_name='dowhile_single',
    termination_condition="$.dowhile_single['iteration'] < 2",
    tasks = task1
)
workflow.add(dowhile_single)
# => OK

dowhile_multiple = DoWhileTask(
    task_ref_name='dowhile_multiple',
    termination_condition="$.dowhile_multiple['iteration'] < 2",
    tasks = [ task1, task2 ]
)
workflow.add(dowhile_multiple)
# => KO
# File "/usr/local/lib/python3.11/site-packages/conductor/client/workflow/task/do_while_task.py", line 32, in to_workflow_task
# workflow.loop_over = get_task_interface_list_as_workflow_task_list(
#                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# TypeError: conductor.client.workflow.task.task.get_task_interface_list_as_workflow_task_list() argument after * must be an iterable, not SimpleTask
``` 

It seems this bug has been introduced along this commit @gardusig https://github.com/conductor-sdk/conductor-python/commit/5b5bf04a5408b799111fc071b7fb62fa2104ac80#diff-6561dd5f4d67f7b315998c89eafc7cee302c3c76e800ee8538b9f7b0594cffdeR9 

The signature of `task.get_task_interface_list_as_workflow_task_list()` changed:
```python
# from:
def get_task_interface_list_as_workflow_task_list(tasks: List[TaskInterface]) -> List[WorkflowTask]:
# to:
def get_task_interface_list_as_workflow_task_list(*tasks: TaskInterface) -> List[WorkflowTask]:
```
... but has not been updated accordingly in the caller class DoWhileTask.

My fix proposal applies the same transformation as `SwitchTask`: https://github.com/conductor-sdk/conductor-python/blob/6b8744d394399bd0d535ac12e412e03c54bee0ef/src/conductor/client/workflow/task/switch_task.py#L26-L31 