### PR TITLE
Fix do while task list and prototype shared tasks

### DIFF
--- a/src/conductor/client/automator/task_handler.py
+++ b/src/conductor/client/automator/task_handler.py
@@ -4,7 +4,6 @@ from conductor.client.configuration.settings.metrics_settings import MetricsSett
 from conductor.client.telemetry.metrics_collector import MetricsCollector
 from conductor.client.worker.worker import Worker
 from conductor.client.worker.worker_interface import WorkerInterface
-from conductor.client.worker.worker_task import WorkerTask
 from multiprocessing import Process, freeze_support
 from typing import List
 import ast

--- a/src/conductor/client/automator/task_runner.py
+++ b/src/conductor/client/automator/task_runner.py
@@ -53,6 +53,7 @@ class TaskRunner:
                 pass
 
     def run_once(self) -> None:
+        self.worker.clear_task_definition_name_cache()
         task = self.__poll_task()
         if task != None and task.task_id != None:
             task_result = self.__execute_task(task)

--- a/src/conductor/client/workflow/conductor_workflow.py
+++ b/src/conductor/client/workflow/conductor_workflow.py
@@ -1,5 +1,3 @@
-from conductor.client.http.models.workflow_def import WorkflowDef
-from conductor.client.http.models.workflow_task import WorkflowTask
 from conductor.client.workflow.task.fork_task import ForkTask
 from conductor.client.workflow.task.join_task import JoinTask
 from conductor.client.workflow.executor.workflow_executor import WorkflowExecutor
@@ -7,7 +5,7 @@ from conductor.client.workflow.task.task import TaskInterface
 from conductor.client.workflow.task.timeout_policy import TimeoutPolicy
 from conductor.client.http.models import *
 from copy import deepcopy
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 from typing_extensions import Self
 from shortuuid import uuid
 
@@ -195,7 +193,7 @@ class ConductorWorkflow:
         return workflow_task_list
 
     # Append task with the right shift operator `>>`
-    def __rshift__(self, task: TaskInterface | List[TaskInterface] | List[List[TaskInterface]]) -> Self:
+    def __rshift__(self, task: Union[TaskInterface, List[TaskInterface], List[List[TaskInterface]]]) -> Self:
         if isinstance(task, list):
             forked_tasks = []
             for fork_task in task:

--- a/src/conductor/client/workflow/task/do_while_task.py
+++ b/src/conductor/client/workflow/task/do_while_task.py
@@ -18,13 +18,16 @@ class DoWhileTask(TaskInterface):
             task_type=TaskType.DO_WHILE,
         )
         self._loop_condition = deepcopy(termination_condition)
-        self._loop_over = deepcopy(tasks)
+        if isinstance(tasks, List):
+            self._loop_over = deepcopy(tasks)
+        else:
+            self._loop_over = [deepcopy(tasks)]
 
     def to_workflow_task(self) -> WorkflowTask:
         workflow = super().to_workflow_task()
         workflow.loop_condition = self._loop_condition
         workflow.loop_over = get_task_interface_list_as_workflow_task_list(
-            self._loop_over,
+            *self._loop_over,
         )
         return workflow
 

--- a/tests/integration/metadata/test_workflow_definition.py
+++ b/tests/integration/metadata/test_workflow_definition.py
@@ -116,6 +116,12 @@ def generate_do_while_task() -> LoopTask:
         tasks=generate_switch_task(),
     )
 
+def generate_do_while_task_multiple() -> LoopTask:
+    return LoopTask(
+        task_ref_name="loop_until_success_multiple",
+        iterations=1,
+        tasks=[generate_simple_task(i) for i in range(13, 14)],
+    )
 
 def generate_fork_task(workflow_executor: WorkflowExecutor) -> ForkTask:
     return ForkTask(
@@ -123,6 +129,7 @@ def generate_fork_task(workflow_executor: WorkflowExecutor) -> ForkTask:
         forked_tasks=[
             [
                 generate_do_while_task(),
+                generate_do_while_task_multiple(),
                 generate_sub_workflow_inline_task(workflow_executor)
             ],
             [generate_simple_task(i) for i in range(3, 5)]

--- a/tests/integration/workflow/test_workflow_execution.py
+++ b/tests/integration/workflow/test_workflow_execution.py
@@ -7,12 +7,12 @@ from conductor.client.worker.worker import Worker
 from conductor.client.workflow.conductor_workflow import ConductorWorkflow
 from conductor.client.workflow.executor.workflow_executor import WorkflowExecutor
 from conductor.client.workflow.task.simple_task import SimpleTask
-from ..resources.worker.python.python_worker import ClassWorker
-from ..resources.worker.python.python_worker import ClassWorkerWithDomain
-from ..resources.worker.python.python_worker import worker_with_generic_input_and_generic_output
-from ..resources.worker.python.python_worker import worker_with_generic_input_and_task_result_output
-from ..resources.worker.python.python_worker import worker_with_task_input_and_generic_output
-from ..resources.worker.python.python_worker import worker_with_task_input_and_task_result_output
+from resources.worker.python.python_worker import ClassWorker
+from resources.worker.python.python_worker import ClassWorkerWithDomain
+from resources.worker.python.python_worker import worker_with_generic_input_and_generic_output
+from resources.worker.python.python_worker import worker_with_generic_input_and_task_result_output
+from resources.worker.python.python_worker import worker_with_task_input_and_generic_output
+from resources.worker.python.python_worker import worker_with_task_input_and_task_result_output
 from time import sleep
 import logging
 

--- a/tests/integration/workflow/test_workflow_execution.py
+++ b/tests/integration/workflow/test_workflow_execution.py
@@ -7,12 +7,12 @@ from conductor.client.worker.worker import Worker
 from conductor.client.workflow.conductor_workflow import ConductorWorkflow
 from conductor.client.workflow.executor.workflow_executor import WorkflowExecutor
 from conductor.client.workflow.task.simple_task import SimpleTask
-from resources.worker.python.python_worker import ClassWorker
-from resources.worker.python.python_worker import ClassWorkerWithDomain
-from resources.worker.python.python_worker import worker_with_generic_input_and_generic_output
-from resources.worker.python.python_worker import worker_with_generic_input_and_task_result_output
-from resources.worker.python.python_worker import worker_with_task_input_and_generic_output
-from resources.worker.python.python_worker import worker_with_task_input_and_task_result_output
+from ..resources.worker.python.python_worker import ClassWorker
+from ..resources.worker.python.python_worker import ClassWorkerWithDomain
+from ..resources.worker.python.python_worker import worker_with_generic_input_and_generic_output
+from ..resources.worker.python.python_worker import worker_with_generic_input_and_task_result_output
+from ..resources.worker.python.python_worker import worker_with_task_input_and_generic_output
+from ..resources.worker.python.python_worker import worker_with_task_input_and_task_result_output
 from time import sleep
 import logging
 

--- a/tests/unit/automator/test_task_runner.py
+++ b/tests/unit/automator/test_task_runner.py
@@ -60,6 +60,21 @@ class TestTaskRunner(unittest.TestCase):
                 spent_time = finish_time - start_time
                 self.assertGreater(spent_time, expected_time)
 
+    def test_run_once_roundrobin(self):
+        with patch.object(
+            TaskResourceApi,
+            'poll',
+            return_value=self.__get_valid_task()
+        ):
+            with patch.object(
+                TaskResourceApi,
+                'update_task',
+            ) as mock_update_task:
+                mock_update_task.return_value = self.UPDATE_TASK_RESPONSE
+                task_runner = self.__get_valid_roundrobin_task_runner()
+                for i in range(0, 6):
+                    task_runner.run_once()
+                    self.assertEqual(task_runner.worker.get_task_definition_name(), self.__shared_task_list[i])
     def test_poll_task(self):
         expected_task = self.__get_valid_task()
         with patch.object(
@@ -176,6 +191,12 @@ class TestTaskRunner(unittest.TestCase):
             worker=self.__get_valid_worker()
         )
 
+    def __get_valid_roundrobin_task_runner(self):
+        return TaskRunner(
+            configuration=Configuration(),
+            worker=self.__get_valid_multi_task_worker()
+        )
+
     def __get_valid_task(self):
         return Task(
             task_id=self.TASK_ID,
@@ -199,3 +220,10 @@ class TestTaskRunner(unittest.TestCase):
 
     def __get_valid_worker(self):
         return ClassWorker('task')
+
+    @property
+    def __shared_task_list(self):
+        return ['task1', 'task2', 'task3', 'task4', 'task5', 'task6']
+
+    def __get_valid_multi_task_worker(self):
+        return ClassWorker(self.__shared_task_list)


### PR DESCRIPTION
Allow sharing task definitions amongst a worker process in order to conserve memory: #219 
Fix DoWhileTask/LoopTask with several subtasks: #220 
