### PR TITLE
Added domain and polling_interval in config and env vars for worker tasks

### DIFF
--- a/docs/worker/README.md
+++ b/docs/worker/README.md
@@ -89,7 +89,7 @@ The arguments that can be passed when defining the decorated worker are:
 ```python
 from conductor.client.worker.worker_task import WorkerTask
 
-@WorkerTask(task_definition_name='python_annotated_task', worker_id='decorated', poll_interval=2.0)
+@WorkerTask(task_definition_name='python_annotated_task', worker_id='decorated', poll_interval=200.0)
 def python_annotated_task(input) -> object:
     return {'message': 'python is so cool :)'}
 ```

--- a/src/conductor/client/automator/task_runner.py
+++ b/src/conductor/client/automator/task_runner.py
@@ -242,16 +242,14 @@ class TaskRunner:
                 # Override polling interval if present in config and not in ENV
                 if not polling_interval_initialized:
                     # Setting to fallback poll interval before reading config
-                    polling_interval = self.worker.poll_interval if self.worker.poll_interval else DEFAULT_POLLING_INTERVAL
+                    default_polling_interval = self.worker.poll_interval
 
                     try:
                         # Read polling interval from config
-                        polling_interval = float(section.get("polling_interval", polling_interval))
+                        self.worker.poll_interval = float(section.get("polling_interval", default_polling_interval))
+                        logger.debug("Override polling interval to {0} ms".format(self.worker.poll_interval))
                     except Exception as e:
-                        logger.error("Exception reading polling interval: {0}. Defaulting to {1} ms".format(str(e), polling_interval))
-                    finally:
-                        self.worker.poll_interval = polling_interval
-
+                        logger.error("Exception reading polling interval: {0}. Defaulting to {1} ms".format(str(e), default_polling_interval))
 
     def __get_property_value_from_env(self, prop, task_type):
         prefix = "conductor_worker"

--- a/src/conductor/client/automator/task_runner.py
+++ b/src/conductor/client/automator/task_runner.py
@@ -6,11 +6,13 @@ from conductor.client.http.models.task import Task
 from conductor.client.http.models.task_result import TaskResult
 from conductor.client.http.models.task_exec_log import TaskExecLog
 from conductor.client.telemetry.metrics_collector import MetricsCollector
-from conductor.client.worker.worker_interface import WorkerInterface
+from conductor.client.worker.worker_interface import WorkerInterface, DEFAULT_POLLING_INTERVAL
+from configparser import ConfigParser
 import logging
 import sys
 import time
 import traceback
+import os
 
 logger = logging.getLogger(
     Configuration.get_logging_formatted_name(
@@ -24,11 +26,14 @@ class TaskRunner:
         self,
         worker: WorkerInterface,
         configuration: Configuration = None,
-        metrics_settings: MetricsSettings = None
+        metrics_settings: MetricsSettings = None,
+        worker_config: ConfigParser =  None
     ):
         if not isinstance(worker, WorkerInterface):
             raise Exception('Invalid worker')
         self.worker = worker
+        self.worker_config = worker_config
+        self.__set_worker_properties()
         if not isinstance(configuration, Configuration):
             configuration = Configuration()
         self.configuration = configuration
@@ -53,12 +58,12 @@ class TaskRunner:
                 pass
 
     def run_once(self) -> None:
-        self.worker.clear_task_definition_name_cache()
         task = self.__poll_task()
         if task != None and task.task_id != None:
             task_result = self.__execute_task(task)
             self.__update_task(task_result)
         self.__wait_for_polling_interval()
+        self.worker.clear_task_definition_name_cache()
 
     def __poll_task(self) -> Task:
         task_definition_name = self.worker.get_task_definition_name()
@@ -97,7 +102,7 @@ class TaskRunner:
             return None
         if task != None:
             logger.debug(
-                f'Polled task: {task_definition_name}, worker_id: {self.worker.get_identity()}'
+                f'Polled task: {task_definition_name}, worker_id: {self.worker.get_identity()}, domain: {self.worker.get_domain()}'
             )
         return task
 
@@ -202,3 +207,60 @@ class TaskRunner:
         polling_interval = self.worker.get_polling_interval_in_seconds()
         logger.debug(f'Sleep for {polling_interval} seconds')
         time.sleep(polling_interval)
+
+    def __set_worker_properties(self) -> None:
+        task_type = self.worker.get_task_definition_name()
+        
+        # Fetch from ENV Variables if present
+        domain = self.__get_property_value_from_env("domain", task_type)
+        if domain:
+            self.worker.domain = domain
+
+        polling_interval = self.__get_property_value_from_env("polling_interval", task_type)
+        polling_interval_initialized = False
+        if polling_interval:
+            try:
+                self.worker.poll_interval = float(polling_interval)
+                polling_interval_initialized = True
+            except Exception as e:
+                logger.error("Exception in reading polling interval from environment variable: {0}.".format(str(e)))
+
+        # Fetch from Config if present
+        if not domain or not polling_interval_initialized:
+            config = self.worker_config
+
+            if config:
+                if config.has_section(task_type):
+                    section = config[task_type]
+                else:
+                    section = config[config.default_section]
+                
+                # Override domain if present in config and not in ENV
+                if not domain:
+                    self.worker.domain = section.get("domain", self.worker.domain)
+
+                # Override polling interval if present in config and not in ENV
+                if not polling_interval_initialized:
+                    # Setting to fallback poll interval before reading config
+                    polling_interval = self.worker.poll_interval if self.worker.poll_interval else DEFAULT_POLLING_INTERVAL
+
+                    try:
+                        # Read polling interval from config
+                        polling_interval = float(section.get("polling_interval", polling_interval))
+                    except Exception as e:
+                        logger.error("Exception reading polling interval: {0}. Defaulting to {1} ms".format(str(e), polling_interval))
+                    finally:
+                        self.worker.poll_interval = polling_interval
+
+
+    def __get_property_value_from_env(self, prop, task_type):
+        prefix = "conductor_worker"
+        # Look for generic property in both case environment variables
+        key = prefix + "_" + prop
+        value_all = os.getenv(key, os.getenv(key.upper()))
+
+        # Look for task specific property in both case environment variables
+        key_small = prefix + "_" + task_type + "_" + prop
+        key_upper = prefix.upper() + "_" + task_type + "_" + prop.upper()
+        value = os.getenv(key_small, os.getenv(key_upper, value_all))
+        return value

--- a/src/conductor/client/worker/worker.py
+++ b/src/conductor/client/worker/worker.py
@@ -37,10 +37,7 @@ class Worker(WorkerInterface):
                  worker_id: str = None,
                  ) -> Self:
         super().__init__(task_definition_name)
-        if poll_interval == None:
-            self.poll_interval = deepcopy(
-                super().get_polling_interval_in_seconds())
-        else:
+        if poll_interval:
             self.poll_interval = deepcopy(poll_interval)
         self.domain = deepcopy(domain)
         if worker_id is None:
@@ -69,12 +66,6 @@ class Worker(WorkerInterface):
 
     def get_identity(self) -> str:
         return self.worker_id
-
-    def get_polling_interval_in_seconds(self) -> float:
-        return self.poll_interval
-
-    def get_domain(self) -> str:
-        return self.domain
 
     @property
     def execute_function(self) -> ExecuteTaskFunction:

--- a/src/conductor/client/worker/worker.py
+++ b/src/conductor/client/worker/worker.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from conductor.client.http.models.task import Task
 from conductor.client.http.models.task_result import TaskResult
 from conductor.client.http.models.task_result_status import TaskResultStatus
-from conductor.client.worker.worker_interface import WorkerInterface
+from conductor.client.worker.worker_interface import WorkerInterface, DEFAULT_POLLING_INTERVAL
 from typing import Any, Callable, Union
 from typing_extensions import Self
 import inspect
@@ -37,7 +37,9 @@ class Worker(WorkerInterface):
                  worker_id: str = None,
                  ) -> Self:
         super().__init__(task_definition_name)
-        if poll_interval:
+        if poll_interval == None:
+            self.poll_interval = DEFAULT_POLLING_INTERVAL
+        else:
             self.poll_interval = deepcopy(poll_interval)
         self.domain = deepcopy(domain)
         if worker_id is None:

--- a/src/conductor/client/worker/worker_interface.py
+++ b/src/conductor/client/worker/worker_interface.py
@@ -5,12 +5,15 @@ import abc
 import socket
 from typing import Union
 
+DEFAULT_POLLING_INTERVAL = 100 # ms
 
 class WorkerInterface(abc.ABC):
     def __init__(self, task_definition_name: Union[str, list]):
         self.task_definition_name = task_definition_name
         self.next_task_index = 0
         self._task_definition_name_cache = None
+        self._domain = None
+        self._poll_interval = None
 
     @abc.abstractmethod
     def execute(self, task: Task) -> TaskResult:
@@ -38,7 +41,7 @@ class WorkerInterface(abc.ABC):
         :return: float
                  Default: 100ms
         """
-        return 0.1
+        return (self.poll_interval  if self.poll_interval else DEFAULT_POLLING_INTERVAL) / 1000
 
     def get_task_definition_name(self) -> str:
         """
@@ -83,10 +86,26 @@ class WorkerInterface(abc.ABC):
 
         :return: str
         """
-        return None
+        return self.domain
 
     def paused(self) -> bool:
         """
         Override this method to pause the worker from polling.
         """
         return False
+
+    @property
+    def domain(self):
+        return self._domain
+
+    @domain.setter
+    def domain(self, value):
+        self._domain = value
+
+    @property
+    def poll_interval(self):
+        return self._poll_interval
+
+    @poll_interval.setter
+    def poll_interval(self, value):
+        self._poll_interval = value

--- a/src/conductor/client/worker/worker_interface.py
+++ b/src/conductor/client/worker/worker_interface.py
@@ -13,7 +13,7 @@ class WorkerInterface(abc.ABC):
         self.next_task_index = 0
         self._task_definition_name_cache = None
         self._domain = None
-        self._poll_interval = None
+        self._poll_interval = DEFAULT_POLLING_INTERVAL
 
     @abc.abstractmethod
     def execute(self, task: Task) -> TaskResult:
@@ -41,7 +41,7 @@ class WorkerInterface(abc.ABC):
         :return: float
                  Default: 100ms
         """
-        return (self.poll_interval  if self.poll_interval else DEFAULT_POLLING_INTERVAL) / 1000
+        return (self.poll_interval if self.poll_interval else DEFAULT_POLLING_INTERVAL) / 1000
 
     def get_task_definition_name(self) -> str:
         """

--- a/tests/integration/main.py
+++ b/tests/integration/main.py
@@ -48,11 +48,13 @@ def main():
     args = sys.argv[1:]
     configuration = generate_configuration()
     api_client = ApiClient(configuration)
+    workflow_executor = WorkflowExecutor(configuration)
 
     if len(args) == 1 and args[0] == '--orkes-clients-only':
         TestOrkesClients(configuration=configuration).run()
+    elif len(args) == 1 and args[0] == '--workflow-execution-only':
+        run_workflow_execution_tests(configuration, workflow_executor)
     else:
-        workflow_executor = WorkflowExecutor(configuration)
         test_async.test_async_method(api_client)
         run_workflow_definition_tests(workflow_executor)
         run_workflow_execution_tests(configuration, workflow_executor)

--- a/tests/integration/resources/worker/python/python_worker.py
+++ b/tests/integration/resources/worker/python/python_worker.py
@@ -11,6 +11,10 @@ class FaultyExecutionWorker(WorkerInterface):
 
 
 class ClassWorker(WorkerInterface):
+    def __init__(self, task_definition_name):
+        super().__init__(task_definition_name)
+        self.poll_interval = 375.0
+
     def execute(self, task: Task) -> TaskResult:
         task_result = self.get_task_result_from_task(task)
         task_result.add_output_data('worker_style', 'class')
@@ -18,13 +22,14 @@ class ClassWorker(WorkerInterface):
         task_result.add_output_data('is_it_true', False)
         task_result.status = TaskResultStatus.COMPLETED
         return task_result
-
-    def get_polling_interval_in_seconds(self) -> float:
-        # poll every 375ms
-        return 0.375
 
 
 class ClassWorkerWithDomain(WorkerInterface):
+    def __init__(self, task_definition_name):
+        super().__init__(task_definition_name)
+        self.poll_interval = 850.0
+        self.domain = 'simple_python_worker'
+
     def execute(self, task: Task) -> TaskResult:
         task_result = self.get_task_result_from_task(task)
         task_result.add_output_data('worker_style', 'class')
@@ -33,23 +38,27 @@ class ClassWorkerWithDomain(WorkerInterface):
         task_result.status = TaskResultStatus.COMPLETED
         return task_result
 
-    def get_polling_interval_in_seconds(self) -> float:
-        # poll every 850ms
-        return 0.850
-
-    def get_domain(self) -> str:
-        return 'simple_python_worker'
-
 
 @WorkerTask(task_definition_name='test_python_decorated_worker')
-def simple_decorated_worker(input) -> object:
-    return {'message': 'python is so cool :)'}
+def decorated_worker(obj: object) -> object:
+    return {
+        'worker_style': 'function',
+        'worker_input': 'Task',
+        'worker_output': 'object',
+        'task_input': obj,
+        'status': 'COMPLETED'
+    }
 
-
-@WorkerTask('test_python_decorated_worker', poll_interval=50.0)
-def decorated_worker_with_poll_interval() -> object:
-    return {'message': 'python is so cool :)'}
-
+@WorkerTask(task_definition_name='test_python_decorated_worker', domain='cool', poll_interval=500.0)
+def decorated_worker_with_domain_and_poll_interval(obj: object) -> object:
+    return {
+        'worker_style': 'function',
+        'worker_input': 'Task',
+        'worker_output': 'object',
+        'domain': 'cool',
+        'task_input': obj,
+        'status': 'COMPLETED'
+    }
 
 def worker_with_task_input_and_task_result_output(task: Task) -> TaskResult:
     task_result = TaskResult(

--- a/tests/integration/resources/worker/python/python_worker.py
+++ b/tests/integration/resources/worker/python/python_worker.py
@@ -46,7 +46,7 @@ def simple_decorated_worker(input) -> object:
     return {'message': 'python is so cool :)'}
 
 
-@WorkerTask('test_python_decorated_worker', poll_interval=0.050)
+@WorkerTask('test_python_decorated_worker', poll_interval=50.0)
 def decorated_worker_with_poll_interval() -> object:
     return {'message': 'python is so cool :)'}
 

--- a/tests/integration/resources/worker/python/python_worker.py
+++ b/tests/integration/resources/worker/python/python_worker.py
@@ -46,9 +46,9 @@ def simple_decorated_worker(input) -> object:
     return {'message': 'python is so cool :)'}
 
 
-# @WorkerTask('test_python_decorated_worker', poll_interval_seconds=0.050)
-# def decorated_worker_with_poll_interval() -> object:
-#     return {'message': 'python is so cool :)'}
+@WorkerTask('test_python_decorated_worker', poll_interval=0.050)
+def decorated_worker_with_poll_interval() -> object:
+    return {'message': 'python is so cool :)'}
 
 
 def worker_with_task_input_and_task_result_output(task: Task) -> TaskResult:

--- a/tests/unit/automator/test_task_handler.py
+++ b/tests/unit/automator/test_task_handler.py
@@ -2,10 +2,12 @@ from conductor.client.automator.task_handler import TaskHandler
 from conductor.client.automator.task_runner import TaskRunner
 from conductor.client.configuration.configuration import Configuration
 from tests.unit.resources.workers import ClassWorker
-from unittest.mock import Mock
+from unittest.mock import Mock, MagicMock
 from unittest.mock import patch
+from configparser import ConfigParser
 import multiprocessing
 import unittest
+import tempfile
 
 
 class PickableMock(Mock):
@@ -14,6 +16,14 @@ class PickableMock(Mock):
 
 
 class TestTaskHandler(unittest.TestCase):
+    def setUp(self) -> None:
+        self.application_properties = tempfile.NamedTemporaryFile(delete=False)
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        self.application_properties.close()
+        return super().tearDown()
+
     def test_initialization_with_invalid_workers(self):
         expected_exception = Exception('Invalid worker list')
         with self.assertRaises(Exception) as context:
@@ -33,6 +43,38 @@ class TestTaskHandler(unittest.TestCase):
                         isinstance(process, multiprocessing.Process)
                     )
 
+    @patch("multiprocessing.Process.kill", Mock(return_value=None))
+    def test_initialize_with_no_worker_config(self):
+        with _get_valid_task_handler() as task_handler:
+            worker_config = task_handler.worker_config
+            self.assertIsInstance(worker_config, ConfigParser)
+            self.assertEqual(len(worker_config.sections()), 0)
+
+    @patch("multiprocessing.Process.kill", Mock(return_value=None))
+    def test_initialize_with_worker_config(self):
+        with tempfile.NamedTemporaryFile(mode='w+') as tf:
+            configParser = ConfigParser()
+            configParser.add_section('task')
+            configParser.set('task', 'domain', 'test')
+            configParser.set('task', 'pollingInterval', '2.0')
+            configParser.add_section('task2')
+            configParser.set('task2', 'domain', 'test2')
+            configParser.set('task2', 'pollingInterval', '3.0')
+            configParser.write(tf)
+            tf.seek(0)
+            
+            def get_config_file_path_mock():
+                return tf.name
+
+            with patch('conductor.client.automator.task_handler.__get_config_file_path', get_config_file_path_mock):
+                with _get_valid_task_handler() as task_handler:
+                    config = task_handler.worker_config
+                    self.assertIsInstance(config, ConfigParser)
+                    self.assertEqual(len(config.sections()), 2)
+                    self.assertEqual(config.get('task', 'domain'), "test")
+                    self.assertEqual(config.get('task', 'pollingInterval'), "2.0")
+                    self.assertEqual(config.get('task2', 'domain'), "test2")
+                    self.assertEqual(config.get('task2', 'pollingInterval'), "3.0")
 
 def _get_valid_task_handler():
     return TaskHandler(

--- a/tests/unit/automator/test_task_handler.py
+++ b/tests/unit/automator/test_task_handler.py
@@ -2,7 +2,7 @@ from conductor.client.automator.task_handler import TaskHandler
 from conductor.client.automator.task_runner import TaskRunner
 from conductor.client.configuration.configuration import Configuration
 from tests.unit.resources.workers import ClassWorker
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock
 from unittest.mock import patch
 from configparser import ConfigParser
 import multiprocessing
@@ -17,11 +17,9 @@ class PickableMock(Mock):
 
 class TestTaskHandler(unittest.TestCase):
     def setUp(self) -> None:
-        self.application_properties = tempfile.NamedTemporaryFile(delete=False)
         return super().setUp()
 
     def tearDown(self) -> None:
-        self.application_properties.close()
         return super().tearDown()
 
     def test_initialization_with_invalid_workers(self):
@@ -56,10 +54,10 @@ class TestTaskHandler(unittest.TestCase):
             configParser = ConfigParser()
             configParser.add_section('task')
             configParser.set('task', 'domain', 'test')
-            configParser.set('task', 'pollingInterval', '2.0')
+            configParser.set('task', 'polling_interval', '200.0')
             configParser.add_section('task2')
             configParser.set('task2', 'domain', 'test2')
-            configParser.set('task2', 'pollingInterval', '3.0')
+            configParser.set('task2', 'polling_interval', '300.0')
             configParser.write(tf)
             tf.seek(0)
             
@@ -72,9 +70,9 @@ class TestTaskHandler(unittest.TestCase):
                     self.assertIsInstance(config, ConfigParser)
                     self.assertEqual(len(config.sections()), 2)
                     self.assertEqual(config.get('task', 'domain'), "test")
-                    self.assertEqual(config.get('task', 'pollingInterval'), "2.0")
+                    self.assertEqual(config.get('task', 'polling_interval'), "200.0")
                     self.assertEqual(config.get('task2', 'domain'), "test2")
-                    self.assertEqual(config.get('task2', 'pollingInterval'), "3.0")
+                    self.assertEqual(config.get('task2', 'polling_interval'), "300.0")
 
 def _get_valid_task_handler():
     return TaskHandler(

--- a/tests/unit/automator/test_task_runner.py
+++ b/tests/unit/automator/test_task_runner.py
@@ -6,7 +6,9 @@ from conductor.client.http.models.task_result import TaskResult
 from conductor.client.http.models.task_result_status import TaskResultStatus
 from tests.unit.resources.workers import ClassWorker
 from tests.unit.resources.workers import FaultyExecutionWorker
-from unittest.mock import patch, ANY
+from conductor.client.worker.worker_interface import DEFAULT_POLLING_INTERVAL
+from configparser import ConfigParser
+from unittest.mock import patch, ANY, Mock
 import logging
 import time
 import unittest
@@ -41,6 +43,58 @@ class TestTaskRunner(unittest.TestCase):
             )
             self.assertEqual(expected_exception, context.exception)
 
+    def test_initialization_without_worker_config(self):
+        task_runner = self.__get_valid_task_runner()
+        self.assertIsNone(task_runner.worker_config)
+
+    def test_initialization_with_no_domain_in_worker_config(self):
+        config = ConfigParser()
+        task_runner = self.__get_valid_task_runner_with_worker_config(config)
+        self.assertEqual(task_runner.worker_config, config)
+        self.assertIsNone(task_runner.worker.domain)
+
+    def test_initialization_with_domain_passed_in_constructor(self):
+        config = ConfigParser()
+        task_runner = self.__get_valid_task_runner_with_worker_config_and_domain(config, "passed")
+        self.assertEqual(task_runner.worker.domain, 'passed')
+
+    def test_initialization_with_generic_domain_in_worker_config(self):
+        config = ConfigParser()
+        config.set('DEFAULT', 'domain', 'generic')
+        task_runner = self.__get_valid_task_runner_with_worker_config_and_domain(config, "passed")
+        self.assertEqual(task_runner.worker.domain, 'generic')
+        
+    def test_initialization_with_specific_domain_in_worker_config(self):
+        config = ConfigParser()
+        config.set('DEFAULT', 'domain', 'generic')
+        config.add_section('task')
+        config.set('task', 'domain', 'test')
+        task_runner = self.__get_valid_task_runner_with_worker_config_and_domain(config, "passed")
+        self.assertEqual(task_runner.worker.domain, 'test')
+
+    def test_initialization_with_default_polling_interval(self):
+        task_runner = self.__get_valid_task_runner()
+        self.assertEqual(task_runner.worker.get_polling_interval_in_seconds() * 1000, DEFAULT_POLLING_INTERVAL)
+
+    def test_initialization_with_polling_interval_passed_in_constructor(self):
+        config = ConfigParser()
+        task_runner = self.__get_valid_task_runner_with_worker_config_and_poll_interval(config, 3000)
+        self.assertEqual(task_runner.worker.get_polling_interval_in_seconds(), 3.0)
+
+    def test_initialization_with_common_polling_interval_in_worker_config(self):
+        config = ConfigParser()
+        config.set('DEFAULT', 'polling_interval', '2000')
+        task_runner = self.__get_valid_task_runner_with_worker_config_and_poll_interval(config, 3000)
+        self.assertEqual(task_runner.worker.get_polling_interval_in_seconds(), 2.0)
+            
+    def test_initialization_with_specific_polling_interval_in_worker_config(self):
+        config = ConfigParser()
+        config.set('DEFAULT', 'polling_interval', '2000')
+        config.add_section('task')
+        config.set('task', 'polling_interval', '5000')
+        task_runner = self.__get_valid_task_runner_with_worker_config_and_poll_interval(config, 3000)
+        self.assertEqual(task_runner.worker.get_polling_interval_in_seconds(), 5.0)
+
     def test_run_once(self):
         expected_time = self.__get_valid_worker().get_polling_interval_in_seconds()
         with patch.object(
@@ -73,8 +127,10 @@ class TestTaskRunner(unittest.TestCase):
                 mock_update_task.return_value = self.UPDATE_TASK_RESPONSE
                 task_runner = self.__get_valid_roundrobin_task_runner()
                 for i in range(0, 6):
+                    current_task_name = task_runner.worker.get_task_definition_name()
                     task_runner.run_once()
-                    self.assertEqual(task_runner.worker.get_task_definition_name(), self.__shared_task_list[i])
+                    self.assertEqual(current_task_name, self.__shared_task_list[i])
+
     def test_poll_task(self):
         expected_task = self.__get_valid_task()
         with patch.object(
@@ -138,13 +194,10 @@ class TestTaskRunner(unittest.TestCase):
         response = task_runner._TaskRunner__update_task(None)
         self.assertEqual(response, expected_response)
 
+    @patch('time.sleep', Mock(return_value=None))
     def test_update_task_with_faulty_task_api(self):
         expected_response = None
-        with patch.object(
-            TaskResourceApi,
-            'update_task',
-            side_effect=Exception()
-        ):
+        with patch.object(TaskResourceApi, 'update_task', side_effect=Exception()):
             task_runner = self.__get_valid_task_runner()
             task_result = self.__get_valid_task_result()
             response = task_runner._TaskRunner__update_task(task_result)
@@ -185,6 +238,27 @@ class TestTaskRunner(unittest.TestCase):
         spent_time = finish_time - start_time
         self.assertGreater(spent_time, expected_time)
 
+    def __get_valid_task_runner_with_worker_config(self, worker_config):
+        return TaskRunner(
+            configuration=Configuration(),
+            worker=self.__get_valid_worker(),
+            worker_config=worker_config
+        )
+
+    def __get_valid_task_runner_with_worker_config_and_domain(self, worker_config, domain):
+        return TaskRunner(
+            configuration=Configuration(),
+            worker=self.__get_valid_worker(domain=domain),
+            worker_config=worker_config
+        )
+
+    def __get_valid_task_runner_with_worker_config_and_poll_interval(self, worker_config, poll_interval):
+        return TaskRunner(
+            configuration=Configuration(),
+            worker=self.__get_valid_worker(poll_interval=poll_interval),
+            worker_config=worker_config
+        )
+
     def __get_valid_task_runner(self):
         return TaskRunner(
             configuration=Configuration(),
@@ -218,12 +292,16 @@ class TestTaskRunner(unittest.TestCase):
             }
         )
 
-    def __get_valid_worker(self):
-        return ClassWorker('task')
-
     @property
     def __shared_task_list(self):
         return ['task1', 'task2', 'task3', 'task4', 'task5', 'task6']
 
     def __get_valid_multi_task_worker(self):
         return ClassWorker(self.__shared_task_list)
+
+    def __get_valid_worker(self, domain=None, poll_interval=None):
+        cw = ClassWorker('task')
+        cw.domain = domain
+        cw.poll_interval = poll_interval
+        return cw
+

--- a/tests/unit/resources/workers.py
+++ b/tests/unit/resources/workers.py
@@ -32,6 +32,7 @@ class SimplePythonWorker(WorkerInterface):
 class ClassWorker(WorkerInterface):
     def __init__(self, task_definition_name: str):
         super().__init__(task_definition_name)
+        self.poll_interval = 50.0
 
     def execute(self, task: Task) -> TaskResult:
         task_result = self.get_task_result_from_task(task)

--- a/tests/unit/resources/workers.py
+++ b/tests/unit/resources/workers.py
@@ -30,6 +30,9 @@ class SimplePythonWorker(WorkerInterface):
 
 
 class ClassWorker(WorkerInterface):
+    def __init__(self, task_definition_name: str):
+        super().__init__(task_definition_name)
+
     def execute(self, task: Task) -> TaskResult:
         task_result = self.get_task_result_from_task(task)
         task_result.add_output_data('worker_style', 'class')
@@ -39,7 +42,3 @@ class ClassWorker(WorkerInterface):
         task_result.add_output_data('case_insensitive_dictionary_ojb',CaseInsensitiveDict(data={'NaMe': 'sdk_worker', 'iDX': 465}))
         task_result.status = TaskResultStatus.COMPLETED
         return task_result
-
-    def get_polling_interval_in_seconds(self) -> float:
-        # poll every 50ms
-        return 0.05


### PR DESCRIPTION
## Worker Configuration

### Using Config File

Added support to read an worker.ini file in the root directory of the worker code that allows for setting default values for task domain and polling intervals for workers. Config file will always override constructor params. These properties are expected to be in the form of: 

```
[task_definition_name]
domain = <domain>
polling_interval = <polling-interval-in-ms>

[DEFAULT]
domain = <domain>
polling_interval = <polling-interval-in-ms>
```

Examples:

```
[DEFAULT]
domain = nice
polling_interval = 2000

[python_annotated_task_1]
domain = cool
polling_interval = 500

[python_annotated_task_2]
domain = hot
polling_interval = 300
```

### Using Environment Variables

Workers can also be configured at run time by using environment variables which override configuration files as well. Environment variables will always override Config file. Upper case ENV vars are also supported but task definition names will be case sensitive.

Examples:

```
CONDUCTOR_WORKER_DOMAIN=nice
conductor_worker_polling_interval=2000
conductor_worker_python_annotated_task_1_domain=cool
CONDUCTOR_WORKER_python_annotated_task_1_POLLING_INTERVAL=500
CONDUCTOR_WORKER_python_annotated_task_2_DOMAIN=hot
conductor_worker_python_annotated_task_2_polling_interval=300
```
