### PR TITLE
Added logging and gracefully terminating workers

### DIFF
--- a/src/conductor/client/automator/task_runner.py
+++ b/src/conductor/client/automator/task_runner.py
@@ -8,18 +8,13 @@ from conductor.client.http.models.task_exec_log import TaskExecLog
 from conductor.client.telemetry.metrics_collector import MetricsCollector
 from conductor.client.worker.worker_interface import WorkerInterface, DEFAULT_POLLING_INTERVAL
 from configparser import ConfigParser
+from logging.handlers import QueueHandler
+from multiprocessing import Queue
 import logging
 import sys
 import time
 import traceback
 import os
-
-logger = logging.getLogger(
-    Configuration.get_logging_formatted_name(
-        __name__
-    )
-)
-
 
 class TaskRunner:
     def __init__(
@@ -48,9 +43,25 @@ class TaskRunner:
             )
         )
 
-    def run(self) -> None:
+    def run(self, queue) -> None:
+        # Setup shared logger using Queues
+        self.logger = logging.getLogger(
+            Configuration.get_logging_formatted_name(
+                __name__
+            )
+        )
+        # Add a handler that uses the shared queue
+        if queue:
+            self.logger.addHandler(QueueHandler(queue))
+        
         if self.configuration != None:
             self.configuration.apply_logging_config()
+        else:
+            self.logger.setLevel(logging.DEBUG)
+        
+        task_names = ','.join(self.worker.task_definition_names)
+        self.logger.info(f'Started worker process for task(s): {task_names}')
+
         while True:
             try:
                 self.run_once()
@@ -68,13 +79,13 @@ class TaskRunner:
     def __poll_task(self) -> Task:
         task_definition_name = self.worker.get_task_definition_name()
         if self.worker.paused():
-            logger.debug(f'Stop polling task for: {task_definition_name}')
+            self.logger.debug(f'Stop polling task for: {task_definition_name}')
             return None
         if self.metrics_collector is not None:
             self.metrics_collector.increment_task_poll(
                 task_definition_name
             )
-        logger.debug(f'Polling task for: {task_definition_name}')
+        self.logger.debug(f'Polling task for: {task_definition_name}')
         try:
             start_time = time.time()
             domain = self.worker.get_domain()
@@ -96,12 +107,12 @@ class TaskRunner:
                 self.metrics_collector.increment_task_poll_error(
                     task_definition_name, type(e)
                 )
-            logger.error(
+            self.logger.error(
                 f'Failed to poll task for: {task_definition_name}, reason: {traceback.format_exc()}'
             )
             return None
         if task != None:
-            logger.debug(
+            self.logger.debug(
                 f'Polled task: {task_definition_name}, worker_id: {self.worker.get_identity()}, domain: {self.worker.get_domain()}'
             )
         return task
@@ -110,7 +121,7 @@ class TaskRunner:
         if not isinstance(task, Task):
             return None
         task_definition_name = self.worker.get_task_definition_name()
-        logger.debug(
+        self.logger.debug(
             'Executing task, id: {task_id}, workflow_instance_id: {workflow_instance_id}, task_definition_name: {task_definition_name}'.format(
                 task_id=task.task_id,
                 workflow_instance_id=task.workflow_instance_id,
@@ -131,7 +142,7 @@ class TaskRunner:
                     task_definition_name,
                     sys.getsizeof(task_result)
                 )
-            logger.debug(
+            self.logger.debug(
                 'Executed task, id: {task_id}, workflow_instance_id: {workflow_instance_id}, task_definition_name: {task_definition_name}'.format(
                     task_id=task.task_id,
                     workflow_instance_id=task.workflow_instance_id,
@@ -152,7 +163,7 @@ class TaskRunner:
             task_result.reason_for_incompletion = str(e)
             task_result.logs = [TaskExecLog(
                 traceback.format_exc(), task_result.task_id, int(time.time()))]
-            logger.error(
+            self.logger.error(
                 'Failed to execute task, id: {task_id}, workflow_instance_id: {workflow_instance_id}, task_definition_name: {task_definition_name}, reason: {reason}'.format(
                     task_id=task.task_id,
                     workflow_instance_id=task.workflow_instance_id,
@@ -166,7 +177,7 @@ class TaskRunner:
         if not isinstance(task_result, TaskResult):
             return None
         task_definition_name = self.worker.get_task_definition_name()
-        logger.debug(
+        self.logger.debug(
             'Updating task, id: {task_id}, workflow_instance_id: {workflow_instance_id}, task_definition_name: {task_definition_name}'.format(
                 task_id=task_result.task_id,
                 workflow_instance_id=task_result.workflow_instance_id,
@@ -179,7 +190,7 @@ class TaskRunner:
                 time.sleep(attempt * 10)
             try:
                 response = self.task_client.update_task(body=task_result)
-                logger.debug(
+                self.logger.debug(
                     'Updated task, id: {task_id}, workflow_instance_id: {workflow_instance_id}, task_definition_name: {task_definition_name}, response: {response}'.format(
                         task_id=task_result.task_id,
                         workflow_instance_id=task_result.workflow_instance_id,
@@ -193,7 +204,7 @@ class TaskRunner:
                     self.metrics_collector.increment_task_update_error(
                         task_definition_name, type(e)
                     )
-                logger.error(
+                self.logger.error(
                     'Failed to update task, id: {task_id}, workflow_instance_id: {workflow_instance_id}, task_definition_name: {task_definition_name}, reason: {reason}'.format(
                         task_id=task_result.task_id,
                         workflow_instance_id=task_result.workflow_instance_id,
@@ -205,10 +216,12 @@ class TaskRunner:
 
     def __wait_for_polling_interval(self) -> None:
         polling_interval = self.worker.get_polling_interval_in_seconds()
-        logger.debug(f'Sleep for {polling_interval} seconds')
+        self.logger.debug(f'Sleep for {polling_interval} seconds')
         time.sleep(polling_interval)
 
     def __set_worker_properties(self) -> None:
+        # If multiple tasks are supplied to the same worker, then only first
+        # task will be considered for setting worker properties
         task_type = self.worker.get_task_definition_name()
         
         # Fetch from ENV Variables if present
@@ -223,7 +236,7 @@ class TaskRunner:
                 self.worker.poll_interval = float(polling_interval)
                 polling_interval_initialized = True
             except Exception as e:
-                logger.error("Exception in reading polling interval from environment variable: {0}.".format(str(e)))
+                self.logger.error("Exception in reading polling interval from environment variable: {0}.".format(str(e)))
 
         # Fetch from Config if present
         if not domain or not polling_interval_initialized:
@@ -247,9 +260,9 @@ class TaskRunner:
                     try:
                         # Read polling interval from config
                         self.worker.poll_interval = float(section.get("polling_interval", default_polling_interval))
-                        logger.debug("Override polling interval to {0} ms".format(self.worker.poll_interval))
+                        self.logger.debug("Override polling interval to {0} ms".format(self.worker.poll_interval))
                     except Exception as e:
-                        logger.error("Exception reading polling interval: {0}. Defaulting to {1} ms".format(str(e), default_polling_interval))
+                        self.logger.error("Exception reading polling interval: {0}. Defaulting to {1} ms".format(str(e), default_polling_interval))
 
     def __get_property_value_from_env(self, prop, task_type):
         prefix = "conductor_worker"

--- a/src/conductor/client/configuration/configuration.py
+++ b/src/conductor/client/configuration/configuration.py
@@ -93,6 +93,17 @@ class Configuration:
         """
         self.__logger_format = value
 
+    @property
+    def log_level(self):
+        """The log level.
+
+        The log_level will be updated when sets logger_format.
+
+        :param value: The format string.
+        :type: str
+        """
+        return self.__log_level
+
     def apply_logging_config(self):
         logging.basicConfig(
             format=self.logger_format,

--- a/src/conductor/client/worker/worker_interface.py
+++ b/src/conductor/client/worker/worker_interface.py
@@ -52,6 +52,13 @@ class WorkerInterface(abc.ABC):
         return self.task_definition_name_cache
 
     @property
+    def task_definition_names(self):
+        if isinstance(self.task_definition_name, list):
+            return self.task_definition_name
+        else:
+            return [self.task_definition_name]
+    
+    @property
     def task_definition_name_cache(self):
         if self._task_definition_name_cache is None:
             self._task_definition_name_cache = self.compute_task_definition_name()


### PR DESCRIPTION
- Fixed logging to make sure the parent TaskHandler process and child TaskRunner worker process logs are logged properly.
- Terminate child processes by default rather than killing them
- Terminate processes when a Keyboard Interrupt is sent from a worker app which calls `join_processes` on TaskHandler


Logs before changes:
```
2023-12-02 16:12:23,975 [32377] conductor.client.automator.task_runner DEBUG    Polling task for: python_execute_example
2023-12-02 16:12:23,977 [32377] conductor.client.automator.task_runner DEBUG    Polling task for: python_execute_example_2
2023-12-02 16:12:23,978 [32377] conductor.client.automator.task_runner DEBUG    Polling task for: python_task_type_b
2023-12-02 16:12:23,980 [32377] conductor.client.automator.task_runner DEBUG    Polling task for: python_task_type_a
2023-12-02 16:12:23,985 urllib3.connectionpool DEBUG    Starting new HTTP connection (1): localhost:8080
2023-12-02 16:12:23,986 urllib3.connectionpool DEBUG    Starting new HTTP connection (1): localhost:8080
2023-12-02 16:12:23,988 urllib3.connectionpool DEBUG    Starting new HTTP connection (1): localhost:8080
2023-12-02 16:12:24,093 urllib3.connectionpool DEBUG    http://localhost:8080 "GET /api/tasks/poll/python_execute_example_2?workerid=e2&domain=hmmm HTTP/1.1" 204 0
2023-12-02 16:12:24,093 urllib3.connectionpool DEBUG    http://localhost:8080 "GET /api/tasks/poll/python_task_type_b?workerid=b&domain=pheww HTTP/1.1" 204 0
2023-12-02 16:12:24,094 urllib3.connectionpool DEBUG    http://localhost:8080 "GET /api/tasks/poll/python_execute_example?workerid=e1&domain=environment HTTP/1.1" 204 0
2023-12-02 16:12:24,094 [32377] conductor.client.automator.task_runner DEBUG    Polled task: python_task_type_b, worker_id: b, domain: pheww
2023-12-02 16:12:24,094 [32377] conductor.client.automator.task_runner DEBUG    Polled task: python_execute_example_2, worker_id: e2, domain: hmmm
2023-12-02 16:12:24,095 [32377] conductor.client.automator.task_runner DEBUG    Sleep for 0.9 seconds
2023-12-02 16:12:24,095 [32377] conductor.client.automator.task_runner DEBUG    Sleep for 3.1 seconds
2023-12-02 16:12:24,095 urllib3.connectionpool DEBUG    http://localhost:8080 "GET /api/tasks/poll/python_task_type_a?workerid=a&domain=environment HTTP/1.1" 204 0
2023-12-02 16:12:24,095 [32377] conductor.client.automator.task_runner DEBUG    Polled task: python_execute_example, worker_id: e1, domain: environment
2023-12-02 16:12:24,096 [32377] conductor.client.automator.task_runner DEBUG    Sleep for 0.9 seconds
2023-12-02 16:12:24,096 [32377] conductor.client.automator.task_runner DEBUG    Polled task: python_task_type_a, worker_id: a, domain: environment
2023-12-02 16:12:24,096 [32377] conductor.client.automator.task_runner DEBUG    Sleep for 2.1 seconds
...
...
...
Traceback (most recent call last):
  File "/Users/abhigupta/Work/orkes/workers/python-domain-worker/main.py", line 78, in <module>
Traceback (most recent call last):
Traceback (most recent call last):
    main()
Traceback (most recent call last):
  File "/Users/abhigupta/Work/orkes/workers/python-domain-worker/main.py", line 75, in main
  File "/Users/abhigupta/.pyenv/versions/3.10.10/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/Users/abhigupta/.pyenv/versions/3.10.10/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/Users/abhigupta/.pyenv/versions/3.10.10/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/abhigupta/.pyenv/versions/3.10.10/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/Users/abhigupta/.pyenv/versions/sdk/lib/python3.10/site-packages/conductor/client/automator/task_runner.py", line 56, in run
    self.run_once()
  File "/Users/abhigupta/.pyenv/versions/3.10.10/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/abhigupta/.pyenv/versions/3.10.10/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/abhigupta/.pyenv/versions/sdk/lib/python3.10/site-packages/conductor/client/automator/task_runner.py", line 65, in run_once
    self.__wait_for_polling_interval()
  File "/Users/abhigupta/.pyenv/versions/sdk/lib/python3.10/site-packages/conduc  File "/Users/abhigupta/.
```


Logs after changes:
```
abhigupta@Abhisheks-MacBook-Pro python-domain-worker % python3 main.py
2023-12-02 16:10:58,274 urllib3.connectionpool DEBUG    Starting new HTTP connection (1): localhost:8080
2023-12-02 16:10:58,357 urllib3.connectionpool DEBUG    http://localhost:8080 "POST /api/token HTTP/1.1" 200 None
2023-12-02 16:10:58,358 [31834] conductor.client.automator.task_handler INFO     Created TaskRunner processes
2023-12-02 16:10:58,358 [31834] conductor.client.automator.task_handler INFO     Created all processes
Number of workers:  4
2023-12-02 16:10:58,359 [31834] conductor.client.automator.task_handler INFO     Starting worker processes...
2023-12-02 16:10:58,358 [31834] conductor.client.automator.task_handler INFO     Created TaskRunner processes
2023-12-02 16:10:58,358 [31834] conductor.client.automator.task_handler INFO     Created TaskRunner processes
2023-12-02 16:10:58,358 [31834] conductor.client.automator.task_handler INFO     Created all processes
2023-12-02 16:10:58,358 [31834] conductor.client.automator.task_handler INFO     Created all processes
2023-12-02 16:10:58,359 [31834] conductor.client.automator.task_handler INFO     Starting worker processes...
2023-12-02 16:10:58,359 [31834] conductor.client.automator.task_handler INFO     Starting worker processes...
2023-12-02 16:10:58,364 [31859] conductor.client.automator.task_runner INFO     Started worker process for task(s): python_execute_example
2023-12-02 16:10:58,364 [31859] conductor.client.automator.task_runner INFO     Started worker process for task(s): python_execute_example
2023-12-02 16:10:58,366 [31859] conductor.client.automator.task_runner DEBUG    Polling task for: python_execute_example
2023-12-02 16:10:58,364 [31859] conductor.client.automator.task_runner INFO     Started worker process for task(s): python_execute_example
2023-12-02 16:10:58,367 [31834] conductor.client.automator.task_handler INFO     Started TaskRunner processes
2023-12-02 16:10:58,368 [31834] conductor.client.automator.task_handler INFO     Started 
2023-12-02 16:10:59,505 [31860] conductor.client.automator.task_runner DEBUG    Polled task: python_execute_example_2, worker_id: e2, domain: hmmm
2023-12-02 16:10:59,505 [31860] conductor.client.automator.task_runner DEBUG    Sleep for 0.9 seconds
2023-12-02 16:10:59,505 [31860] conductor.client.automator.task_runner DEBUG    Sleep for 0.9 seconds
2023-12-02 16:10:59,505 [31859] conductor.client.automator.task_runner DEBUG    Polled task: python_execute_example, 
....
....
....
2023-12-02 16:11:00,119 [31834] conductor.client.automator.task_handler INFO     KeyboardInterrupt: Stopping all processes
2023-12-02 16:11:00,119 [31834] conductor.client.automator.task_handler DEBUG    Terminating process: 31859
2023-12-02 16:11:00,120 [31834] conductor.client.automator.task_handler DEBUG    Terminating process: 31860
2023-12-02 16:11:00,120 [31834] conductor.client.automator.task_handler DEBUG    Terminating process: 31861
2023-12-02 16:11:00,120 [31834] conductor.client.automator.task_handler DEBUG    Terminating process: 31862
2023-12-02 16:11:00,120 [31834] conductor.client.automator.task_handler INFO     Stopped worker processes...
2023-12-02 16:11:00,120 [31834] conductor.client.automator.task_handler INFO     Stopping logger process...
```
