### PR TITLE
Fixed typing error for > Python 3.11

### DIFF
--- a/src/conductor/client/http/models/state_change_event.py
+++ b/src/conductor/client/http/models/state_change_event.py
@@ -1,5 +1,6 @@
 from enum import Enum
-from typing import Self, Union, List
+from typing import Union, List
+from typing_extensions import Self
 
 
 class StateChangeEventType(Enum):

--- a/src/conductor/client/http/models/workflow_task.py
+++ b/src/conductor/client/http/models/workflow_task.py
@@ -1,6 +1,6 @@
 import pprint
 import re  # noqa: F401
-from typing import List, Union, Self
+from typing import List
 
 import six
 


### PR DESCRIPTION
Fixes this error that happens in versions less than 3.11

```
    from conductor.client.workflow.task.http_task import HttpTask, HttpInput
  File "/usr/local/lib/python3.9/site-packages/conductor/client/workflow/task/http_task.py", line 7, in <module>
    from conductor.client.workflow.task.task import TaskInterface
  File "/usr/local/lib/python3.9/site-packages/conductor/client/workflow/task/task.py", line 7, in <module>
    from conductor.client.http.models.workflow_task import WorkflowTask
  File "/usr/local/lib/python3.9/site-packages/conductor/client/http/models/__init__.py", line 34, in <module>
    from conductor.client.http.models.workflow_task import WorkflowTask
  File "/usr/local/lib/python3.9/site-packages/conductor/client/http/models/workflow_task.py", line 3, in <module>
    from typing import List, Union, Self
ImportError: cannot import name 'Self' from 'typing' (/usr/lib64/python3.9/typing.py)
```