### PR TITLE
FIX - Dynamic Fork (workflow as code) 

### DIFF
--- a/src/conductor/client/workflow/task/dynamic_fork_task.py
+++ b/src/conductor/client/workflow/task/dynamic_fork_task.py
@@ -9,27 +9,21 @@ from conductor.client.workflow.task.task_type import TaskType
 
 
 class DynamicForkTask(TaskInterface):
-    def __init__(self, task_ref_name: str, pre_fork_task: TaskInterface, join_task: JoinTask = None) -> Self:
+    def __init__(self, task_ref_name: str, tasks_param: str = 'dynamicTasks', tasks_input_param_name: str = 'dynamicTasksInput', join_task: JoinTask = None) -> Self:
         super().__init__(
             task_reference_name=task_ref_name,
             task_type=TaskType.FORK_JOIN_DYNAMIC
         )
-        self._pre_fork_task = deepcopy(pre_fork_task)
+        self.tasks_param = tasks_param
+        self.tasks_input_param_name = tasks_input_param_name
         self._join_task = deepcopy(join_task)
 
     def to_workflow_task(self) -> WorkflowTask:
-        workflow = super().to_workflow_task()
-        workflow.dynamic_fork_join_tasks_param = 'forkedTasks'
-        workflow.dynamic_fork_tasks_input_param_name = 'forkedTasksInputs'
-        workflow.input_parameters['forkedTasks'] = self._pre_fork_task.output_ref(
-            'forkedTasks'
-        )
-        workflow.input_parameters['forkedTasksInputs'] = self._pre_fork_task.output_ref(
-            'forkedTasksInputs'
-        )
+        wf_task = super().to_workflow_task()
+        wf_task.dynamic_fork_join_tasks_param = self.tasks_param
+        wf_task.dynamic_fork_tasks_input_param_name = self.tasks_input_param_name
         tasks = [
-            self._pre_fork_task.to_workflow_task(),
-            workflow,
+            wf_task,
         ]
         if self._join_task != None:
             tasks.append(self._join_task.to_workflow_task())

--- a/src/conductor/client/workflow/task/dynamic_fork_task.py
+++ b/src/conductor/client/workflow/task/dynamic_fork_task.py
@@ -9,7 +9,7 @@ from conductor.client.workflow.task.task_type import TaskType
 
 
 class DynamicForkTask(TaskInterface):
-    def __init__(self, task_ref_name: str, tasks_param: str = 'dynamicTasks', tasks_input_param_name: str = 'dynamicTasksInput', join_task: JoinTask = None) -> Self:
+    def __init__(self, task_ref_name: str, tasks_param: str = 'dynamicTasks', tasks_input_param_name: str = 'dynamicTasksInputs', join_task: JoinTask = None) -> Self:
         super().__init__(
             task_reference_name=task_ref_name,
             task_type=TaskType.FORK_JOIN_DYNAMIC

--- a/src/conductor/client/workflow/task/task.py
+++ b/src/conductor/client/workflow/task/task.py
@@ -11,7 +11,13 @@ from conductor.client.workflow.task.task_type import TaskType
 def get_task_interface_list_as_workflow_task_list(*tasks: Self) -> List[WorkflowTask]:
     converted_tasks = []
     for task in tasks:
-        converted_tasks.append(task.to_workflow_task())
+        wf_task = task.to_workflow_task()
+        if isinstance(wf_task, list):
+            # to_workflow_task() returned a list. E.g.: DynamicFork.to_workflow_task() returns the DynamicFork and the Join task.
+            for t in wf_task:
+                converted_tasks.append(t)
+        else:
+            converted_tasks.append(task.to_workflow_task())
     return converted_tasks
 
 

--- a/tests/integration/metadata/test_workflow_definition.py
+++ b/tests/integration/metadata/test_workflow_definition.py
@@ -167,7 +167,6 @@ def generate_set_variable_task() -> SetVariableTask:
 def generate_dynamic_fork_task() -> DynamicForkTask:
     return DynamicForkTask(
         task_ref_name='dynamic_fork',
-        pre_fork_task=generate_simple_task(10),
         join_task=JoinTask(
             'join', join_on=[]
         ),


### PR DESCRIPTION
The `DynamicForkTask` in its current state is non-functional. It requires a "pre_fork_task" and the dynamic tasks and their inputs are supposed to be taken from its output.

It's not working and it's too rigid. It won't allow using an INLINE task (given how this task outputs the result), it won't allow setting the dynamic tasks and inputs in the task def itself, or take it from a workflow input.

**TODO** (in an upcoming PR)
- When creating tasks it's just using task ref name. Task name should also be an option.  
- Tests + refactoring.

**NOTES** 

- I've tested this with this [code](https://gist.github.com/jmigueprieto/3ad5153eef2f92cb86d2cc5fe788525a) and generated the correct workflow.

<img width="1200" alt="Screenshot 2025-01-14 at 15 42 54" src="https://github.com/user-attachments/assets/129225d0-6ff9-4bfa-9002-5a855e93c219" />

