### PR TITLE
Fix worker output serialization issues

### DIFF
--- a/src/conductor/client/http/api_client.py
+++ b/src/conductor/client/http/api_client.py
@@ -212,9 +212,13 @@ class ApiClient(object):
                             for attr, _ in six.iteritems(obj.swagger_types)
                             if getattr(obj, attr) is not None}
             else:
-                obj_dict = {name: getattr(obj, name)
-                            for name in vars(obj)
-                            if getattr(obj, name) is not None}
+                try:
+                    obj_dict = {name: getattr(obj, name)
+                                for name in vars(obj)
+                                if getattr(obj, name) is not None}
+                except TypeError:
+                    # Fallback to string representation.
+                    return str(obj)
 
         return {key: self.sanitize_for_serialization(val)
                 for key, val in six.iteritems(obj_dict)}

--- a/tests/unit/api_client/test_api_client.py
+++ b/tests/unit/api_client/test_api_client.py
@@ -1,0 +1,12 @@
+import unittest
+import uuid
+from conductor.client.http.api_client import ApiClient
+
+
+class TestOrkesAuthorizationClient(unittest.TestCase):
+
+    def test_sanitize_for_serialization_with_uuid(self):
+        api_client = ApiClient()
+        obj = uuid.uuid4()
+        sanitized = api_client.sanitize_for_serialization(obj)
+        self.assertEquals(str(obj), sanitized)


### PR DESCRIPTION
Fix serialization of UUID (and others) by falling back to string representation.

Reported in Slack: https://orkes-conductor.slack.com/archives/C02UQ3GNVBL/p1737637408509809

**NOTES**
The returned string is put into the `"result"` of a JSON object.  E.g.:

```json
{
  "result": "49d57e8e-4b7c-4142-a59a-7b04432e0c52"
}
```