### PR TITLE
Fix wrong test class name

### DIFF
--- a/tests/unit/api_client/test_api_client.py
+++ b/tests/unit/api_client/test_api_client.py
@@ -3,7 +3,7 @@ import uuid
 from conductor.client.http.api_client import ApiClient
 
 
-class TestOrkesAuthorizationClient(unittest.TestCase):
+class TestApiClient(unittest.TestCase):
 
     def test_sanitize_for_serialization_with_uuid(self):
         api_client = ApiClient()


### PR DESCRIPTION
Minor follow-up of https://github.com/conductor-sdk/conductor-python/pull/275. I just realized the class name is wrong (was caught copy-pasting).