### PR TITLE
Added missing OAuth2 fields

### DIFF
--- a/src/conductor/asyncio_client/adapters/models/integration_def_form_field_adapter.py
+++ b/src/conductor/asyncio_client/adapters/models/integration_def_form_field_adapter.py
@@ -93,6 +93,10 @@ class IntegrationDefFormFieldAdapter(IntegrationDefFormField):
                 "valueSubjectNameStrategy",
                 "version",
                 "visibilityTimeout",
+                "oAuth2RefreshToken",
+                "oAuth2AuthCode",
+                "oAuth2TokenExpiresAt",
+                "oAuth2RedirectUri",
             ]
         ):
             raise ValueError(
@@ -111,7 +115,7 @@ class IntegrationDefFormFieldAdapter(IntegrationDefFormField):
                 "'schemaRegistryApiSecret', 'schemaRegistryAuthType', 'schemaRegistryUrl', "
                 "'serviceAccountCredentials', 'stream', 'subscription', 'tls', 'tlsFile', "
                 "'truststoreAuthenticationType', 'user', 'valueSubjectNameStrategy', "
-                "'version', 'visibilityTimeout'"
+                "'version', 'visibilityTimeout', 'oAuth2RefreshToken', 'oAuth2AuthCode', 'oAuth2TokenExpiresAt', 'oAuth2RedirectUri'"
                 ")"
             )
 

--- a/src/conductor/client/adapters/models/integration_def_form_field_adapter.py
+++ b/src/conductor/client/adapters/models/integration_def_form_field_adapter.py
@@ -69,6 +69,10 @@ class IntegrationDefFormFieldAdapter(IntegrationDefFormField):
             "betaVersion",
             "version",
             "organizationId",
+            "oAuth2RefreshToken",
+            "oAuth2AuthCode",
+            "oAuth2TokenExpiresAt",
+            "oAuth2RedirectUri",
         ]
         if field_name not in allowed_values:
             raise ValueError(


### PR DESCRIPTION
Changes:

Added OAuth2 related field names to IntegrationDefFormFieldAdapter (oAuth2RefreshToken, oAuth2AuthCode, oAuth2TokenExpiresAt, oAuth2RedirectUri)