### PR TITLE
Type fix: HTTPInput.Headers unexpected type Dict[str,List[str]]

### DIFF
--- a/src/conductor/client/workflow/task/http_poll_task.py
+++ b/src/conductor/client/workflow/task/http_poll_task.py
@@ -48,7 +48,7 @@ class HttpPollInput():
                  polling_strategy: str = "FIXED",
                  method: HttpMethod = HttpMethod.GET,
                  uri: Optional[str] = None,
-                 headers: Optional[Dict[str, List[str]]] = None,
+                 headers: Optional[Dict[str, str]] = None,
                  accept: Optional[str] = None,
                  content_type: Optional[str] = None,
                  connection_time_out: Optional[int] = None,

--- a/src/conductor/client/workflow/task/http_task.py
+++ b/src/conductor/client/workflow/task/http_task.py
@@ -44,7 +44,7 @@ class HttpInput:
     def __init__(self,
                  method: HttpMethod = HttpMethod.GET,
                  uri: Optional[str] = None,
-                 headers: Optional[Dict[str, List[str]]] = None,
+                 headers: Optional[Dict[str, str]] = None,
                  accept: Optional[str] = None,
                  content_type: Optional[str] = None,
                  connection_time_out: Optional[int] = None,


### PR DESCRIPTION
Hello,

Shouldn't HTTP Headers be a dict[str, str] instead of [str, List[str]]?

Orkes UI also complains about this:
<img width="869" height="385" alt="image" src="https://github.com/user-attachments/assets/da0e8f38-91b6-4df8-bac8-faa71199cdaa" />

And I receive this headers:
<img width="456" height="227" alt="image" src="https://github.com/user-attachments/assets/73f02381-b0e6-4c28-a74e-b1ba3c2665a4" />

Either the issue is in the typing or marshalling the data.