### PR TITLE
1.2.3 version Bugfix: README example broken

### DIFF
--- a/src/conductor/client/workflow/task/task.py
+++ b/src/conductor/client/workflow/task/task.py
@@ -33,12 +33,12 @@ class TaskInterface():
                  cache_ttl_second: int = 0) -> Self:
         self.task_reference_name = task_reference_name
         self.task_type = task_type
-        self.task_name = task_name if task_name is not None else task_type.value
+        self.name = task_name or task_reference_name
         self.description = description
         self.optional = optional
-        self.input_parameters = input_parameters if input_parameters is not None else {}
-        self.cache_key = cache_key
-        self.cache_ttl_second = cache_ttl_second
+        self.input_parameters = input_parameters
+        self._cache_key = cache_key
+        self._cache_ttl_second = cache_ttl_second
         self._expression = None
         self._evaluator_type = None
 
@@ -175,7 +175,7 @@ class TaskInterface():
             else:
                 return "${" + f"{self.task_reference_name}.input.{json_path}" + "}"
 
-    def __getattribute__(self, __name: str, /) -> Any:
+    def __getattribute__(self, __name: str) -> Any:
         try:
             val = super().__getattribute__(__name)
             return val


### PR DESCRIPTION
This bug initially appeared in version 1.1.11 and was later fixed by 1.2.0 release. Since the version was restored back to 1.1.11 on top of which the 1.2.3 version was built  the bug remained there

The issue link: https://github.com/conductor-oss/python-sdk/issues/364