### PR TITLE
Bump vulnerable dependencies (filelock, urllib3, virtualenv)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ deprecated = ">=1.2.14"
 python-dateutil = "^2.8.2"
 httpx = {version = ">=0.26.0", extras = ["http2"]}
 h2 = ">=4.1.0"
+urllib3 = ">=2.6.3"
 
 [tool.poetry.group.dev.dependencies]
 pylint = ">=2.17.5"
@@ -45,6 +46,8 @@ ruff = "^0.12.0"
 pre-commit = "^4.2.0"
 setuptools = "^80.9.0"
 pytest = "^8.4.1"
+filelock = ">=3.20.3"
+virtualenv = ">=20.36.1"
 
 [tool.ruff]
 target-version = "py39"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ dacite >= 1.8.1
 deprecated >= 1.2.14
 httpx >=0.26.0
 python-dateutil >= 2.8.2
+urllib3 >= 2.6.3


### PR DESCRIPTION
## Summary
- Add minimum version constraints for vulnerable dependencies
- urllib3 >= 2.6.3, filelock >= 3.20.3, virtualenv >= 20.36.1

## Vulnerabilities Fixed
| Package | Installed | Fixed | Issues |
|---------|-----------|-------|--------|
| urllib3 | 2.5.0 | >= 2.6.3 | GHSA-38jv-5279-wg99, GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53 |
| filelock | 3.18.0 | >= 3.20.3 | GHSA-qmgc-5h2g-mvrw, GHSA-w853-jp5j-5j7f |
| virtualenv | 20.31.2 | >= 20.36.1 | GHSA-597g-3phw-6986 |

Fixes #379, #380, #381