### PR TITLE
feat: add ConductorClients as alias for OrkesClients

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Create a `quickstart.py` with the following:
 ```python
 from conductor.client.automator.task_handler import TaskHandler
 from conductor.client.configuration.configuration import Configuration
-from conductor.client.orkes_clients import OrkesClients  # works with OSS Conductor and Orkes Conductor
+from conductor.client.orkes_clients import ConductorClients  # OrkesClients is an alias for the same class
 from conductor.client.workflow.conductor_workflow import ConductorWorkflow
 from conductor.client.worker.worker_task import worker_task
 
@@ -121,7 +121,7 @@ def main():
     # Configure the SDK (reads CONDUCTOR_SERVER_URL / CONDUCTOR_AUTH_* from env).
     config = Configuration()
 
-    clients = OrkesClients(configuration=config)
+    clients = ConductorClients(configuration=config)
     executor = clients.get_workflow_executor()
 
     # Build a workflow with the >> operator.
@@ -329,10 +329,10 @@ Full lifecycle control — start, execute, pause, resume, terminate, retry, rest
 ```python
 from conductor.client.configuration.configuration import Configuration
 from conductor.client.http.models import StartWorkflowRequest, RerunWorkflowRequest, TaskResult
-from conductor.client.orkes_clients import OrkesClients
+from conductor.client.orkes_clients import ConductorClients
 
 config = Configuration()
-clients = OrkesClients(configuration=config)
+clients = ConductorClients(configuration=config)
 workflow_client = clients.get_workflow_client()
 task_client = clients.get_task_client()
 executor = clients.get_workflow_executor()

--- a/src/conductor/client/__init__.py
+++ b/src/conductor/client/__init__.py
@@ -3,7 +3,7 @@
 from conductor.client.configuration.configuration import Configuration
 from conductor.client.automator.task_handler import TaskHandler
 from conductor.client.automator.task_runner import TaskRunner
-from conductor.client.orkes_clients import OrkesClients
+from conductor.client.orkes_clients import OrkesClients, ConductorClients
 from conductor.client.workflow.conductor_workflow import ConductorWorkflow
 from conductor.client.workflow.executor.workflow_executor import WorkflowExecutor
 from conductor.client.worker.worker_task import worker_task
@@ -18,6 +18,7 @@ __all__ = [
     "TaskHandler",
     "TaskRunner",
     "OrkesClients",
+    "ConductorClients",
     "ConductorWorkflow",
     "WorkflowExecutor",
     "worker_task",

--- a/src/conductor/client/orkes_clients.py
+++ b/src/conductor/client/orkes_clients.py
@@ -55,3 +55,6 @@ class OrkesClients:
 
     def get_schema_client(self) -> SchemaClient:
         return OrkesSchemaClient(self.configuration)
+
+
+ConductorClients = OrkesClients

--- a/tests/unit/test_conductor_clients.py
+++ b/tests/unit/test_conductor_clients.py
@@ -1,0 +1,33 @@
+from conductor.client.orkes_clients import OrkesClients, ConductorClients
+from conductor.client import ConductorClients as ConductorClientsFromPkg
+from conductor.client.configuration.configuration import Configuration
+
+
+def test_alias_is_same_class():
+    assert ConductorClients is OrkesClients
+
+
+def test_package_export_is_same_class():
+    assert ConductorClientsFromPkg is OrkesClients
+
+
+def test_conductor_clients_instantiates():
+    config = Configuration(server_api_url='http://localhost:8080/api')
+    clients = ConductorClients(configuration=config)
+    assert isinstance(clients, OrkesClients)
+
+
+def test_conductor_clients_default_config():
+    clients = ConductorClients()
+    assert clients.configuration is not None
+
+
+def test_conductor_clients_get_methods():
+    config = Configuration(server_api_url='http://localhost:8080/api')
+    clients = ConductorClients(configuration=config)
+    assert clients.get_workflow_executor() is not None
+    assert clients.get_workflow_client() is not None
+    assert clients.get_task_client() is not None
+    assert clients.get_metadata_client() is not None
+    assert clients.get_scheduler_client() is not None
+    assert clients.get_secret_client() is not None


### PR DESCRIPTION
## Summary

- Adds `ConductorClients = OrkesClients` to `orkes_clients.py` — a zero-behavior-change alias
- Exports `ConductorClients` from `conductor.client` alongside `OrkesClients`
- Updates the README quickstart and Feature Showcase examples to use `ConductorClients`

`OrkesClients` remains fully intact; this is additive only.

**User impact:** OSS users following the quickstart no longer have to import a class named `OrkesClients` and wonder if they need an Orkes account. Both names work — `ConductorClients` for new code, `OrkesClients` for anyone who already has it.

Closes conductor-oss/getting-started#45