### PR TITLE
fix: lease heartbeat 500 error and remove fork override in tests

### DIFF
--- a/src/conductor/client/automator/lease_tracker.py
+++ b/src/conductor/client/automator/lease_tracker.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 from conductor.client.http.models.task_result import TaskResult
+from conductor.client.http.models.task_result_status import TaskResultStatus
 
 logger = logging.getLogger(__name__)
 
@@ -196,6 +197,7 @@ class LeaseManager:
             task_id=info.task_id,
             workflow_instance_id=info.workflow_instance_id,
             extend_lease=True,
+            status=TaskResultStatus.IN_PROGRESS,
         )
         for attempt in range(LEASE_EXTEND_RETRY_COUNT):
             try:

--- a/tests/integration/workflow/test_workflow_execution.py
+++ b/tests/integration/workflow/test_workflow_execution.py
@@ -1,6 +1,5 @@
 import logging
 import time
-from multiprocessing import set_start_method
 from time import sleep
 
 from conductor.client.automator.task_handler import TaskHandler
@@ -45,7 +44,6 @@ def run_workflow_execution_tests(configuration: Configuration, workflow_executor
         scan_for_annotated_workers=True,
         import_modules=['tests.integration.resources.worker.python.python_worker']
     )
-    set_start_method('fork', force=True)
     task_handler.start_processes()
     try:
         test_get_workflow_by_correlation_ids(workflow_executor)


### PR DESCRIPTION
## What

Two bugs found during macOS spawn-safety testing.

**1. Lease heartbeat → 500 on server**
Heartbeat was sent without a `status` field. Server NPEs calling `getStatus().name()` when status is null. Fixed by including `status=IN_PROGRESS` in heartbeat requests.

**2. Integration test forces fork, breaks spawn default**
`test_workflow_execution.py` had `set_start_method('fork', force=True)` which overrode the SDK's spawn default for the whole pytest session, causing SIGSEGV crashes on macOS for subsequent tests. Removed.

## Tested
- 1850 unit tests pass on Python 3.11, 3.13, 3.14
- Comprehensive E2E 8/8 passes on live cluster