### PR TITLE
feat(workflow): add LambdaTask builder for TaskType.LAMBDA

### DIFF
--- a/src/conductor/client/workflow/task/lambda_task.py
+++ b/src/conductor/client/workflow/task/lambda_task.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+from typing import Dict, Optional
+from typing_extensions import Self
+
+from conductor.client.workflow.task.task import TaskInterface
+from conductor.client.workflow.task.task_type import TaskType
+
+
+class LambdaTask(TaskInterface):
+    def __init__(self, task_ref_name: str, script: str, bindings: Optional[Dict[str, str]] = None) -> Self:
+        super().__init__(
+            task_reference_name=task_ref_name,
+            task_type=TaskType.LAMBDA,
+            input_parameters={
+                "scriptExpression": script,
+            }
+        )
+        if bindings is not None:
+            self.input_parameters.update(bindings)

--- a/tests/unit/workflow/test_lambda_task.py
+++ b/tests/unit/workflow/test_lambda_task.py
@@ -1,0 +1,26 @@
+from conductor.client.workflow.task.lambda_task import LambdaTask
+from conductor.client.workflow.task.task_type import TaskType
+
+SCRIPT = "(function(){ return {out: $.x + 1}; })()"
+
+
+def test_lambda_task_builds_script_expression():
+    task = LambdaTask(task_ref_name="lambda_ref", script=SCRIPT)
+    assert task.task_reference_name == "lambda_ref"
+    assert task.input_parameters == {"scriptExpression": SCRIPT}
+
+    workflow_task = task.to_workflow_task()
+    assert workflow_task.type == TaskType.LAMBDA.value
+    assert workflow_task.input_parameters["scriptExpression"] == SCRIPT
+
+
+def test_lambda_task_merges_bindings():
+    task = LambdaTask(
+        task_ref_name="lambda_ref",
+        script=SCRIPT,
+        bindings={"x": "${workflow.input.x}"},
+    )
+    assert task.input_parameters == {
+        "scriptExpression": SCRIPT,
+        "x": "${workflow.input.x}",
+    }


### PR DESCRIPTION
## Summary

Closes #427

`TaskType.LAMBDA` is present in the SDK's enum, but there was no `LambdaTask` builder class, so LAMBDA tasks could only be constructed from raw dicts. This adds the missing builder.

## Change

Add `src/conductor/client/workflow/task/lambda_task.py` with a `LambdaTask` that mirrors `InlineTask`: it sets `scriptExpression` from the `script` argument and merges any `bindings` into `input_parameters`. The resulting workflow task serializes with `type: "LAMBDA"` and the expected `inputParameters`, matching the server-side shape in the issue.

```python
from conductor.client.workflow.task.lambda_task import LambdaTask

LambdaTask(
    task_ref_name="compute",
    script="(function(){ return {out: $.x + 1}; })()",
    bindings={"x": "${workflow.input.x}"},
)
```

## Tests

Added `tests/unit/workflow/test_lambda_task.py`, covering the `scriptExpression` construction, the `to_workflow_task()` type (`LAMBDA`), and bindings merge. Both pass against the SDK.
