### PR TITLE
fix: restore dynamic_fork_tasks_param in DynamicForkTask (re-fixes #349)

### DIFF
--- a/src/conductor/client/workflow/task/dynamic_fork_task.py
+++ b/src/conductor/client/workflow/task/dynamic_fork_task.py
@@ -20,7 +20,7 @@ class DynamicForkTask(TaskInterface):
 
     def to_workflow_task(self) -> WorkflowTask:
         wf_task = super().to_workflow_task()
-        wf_task.dynamic_fork_join_tasks_param = self.tasks_param
+        wf_task.dynamic_fork_tasks_param = self.tasks_param
         wf_task.dynamic_fork_tasks_input_param_name = self.tasks_input_param_name
         tasks = [
             wf_task,

--- a/tests/unit/workflow/test_dynamic_fork_task.py
+++ b/tests/unit/workflow/test_dynamic_fork_task.py
@@ -1,0 +1,32 @@
+import unittest
+
+from conductor.client.workflow.task.dynamic_fork_task import DynamicForkTask
+from conductor.client.workflow.task.join_task import JoinTask
+
+
+class TestDynamicForkTask(unittest.TestCase):
+    def test_to_workflow_task_uses_dynamic_fork_tasks_param(self):
+        task = DynamicForkTask(
+            task_ref_name="fork",
+            tasks_param="myTasks",
+            tasks_input_param_name="myTasksInput",
+        )
+        tasks = task.to_workflow_task()
+        wf_task = tasks[0]
+        self.assertEqual(wf_task.dynamic_fork_tasks_param, "myTasks")
+        self.assertEqual(wf_task.dynamic_fork_tasks_input_param_name, "myTasksInput")
+        self.assertIsNone(wf_task.dynamic_fork_join_tasks_param)
+
+    def test_to_workflow_task_with_join(self):
+        join = JoinTask("join", join_on=[])
+        task = DynamicForkTask(task_ref_name="fork", join_task=join)
+        tasks = task.to_workflow_task()
+        self.assertEqual(len(tasks), 2)
+        self.assertEqual(tasks[0].dynamic_fork_tasks_param, "dynamicTasks")
+        self.assertEqual(tasks[0].dynamic_fork_tasks_input_param_name, "dynamicTasksInputs")
+        self.assertIsNone(tasks[0].dynamic_fork_join_tasks_param)
+        self.assertEqual(tasks[1].task_reference_name, "join")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Re-applies the one-line fix from PR #352, which was dropped from main when the branch was subsequently force-pushed/rebased (likely during the Agentspan consolidation). GitHub still shows #352 as \"Merged\" because it records the merge event, but commit a561d901 is not an ancestor of current main.

**Actual timeline:**
- **baadd201 (Jan 2025)** — PR #274 redesigned `DynamicForkTask` (replaced `pre_fork_task` with `tasks_param`/`tasks_input_param_name`) but set the wrong field: `dynamic_fork_join_tasks_param` instead of `dynamic_fork_tasks_param`. This is the bug.
- **PR #352 (Oct 2025)** — Igor fixed the field name. Fix merged but lost when main was rewritten.
- **This PR** — Re-applies the same fix and adds unit tests to catch any future regression.

Setting `dynamic_fork_join_tasks_param` alongside `dynamic_fork_tasks_input_param_name` violates Conductor's validation: only one approach is valid at a time (`dynamicForkJoinTasksParam` alone, or `dynamicForkTasksParam` + `dynamicForkTasksInputParamName` together).

**User impact:** Users calling `DynamicForkTask` with separate `tasks_param` / `tasks_input_param_name` would get a 400 validation error from the server on workflow registration. Now registers correctly.

## Test plan

- [x] `tests/unit/workflow/test_dynamic_fork_task.py` — two new unit tests cover the correct param and the join-task variant
- [x] Integration test `generate_dynamic_fork_task` in `tests/integration/metadata/test_workflow_definition.py` already exercises this path against a live server

Fixes #377