### PR TITLE
test: skip agent e2e when LLM budget is exhausted

### DIFF
--- a/e2e/test_suite1_basic_validation.py
+++ b/e2e/test_suite1_basic_validation.py
@@ -360,13 +360,18 @@ def _judge_call_anthropic(model: str, system: str, user: str) -> str:
         )
 
     client = anthropic.Anthropic()  # reads ANTHROPIC_API_KEY from env
-    response = client.messages.create(
-        model=model,
-        max_tokens=1024,
-        system=system,
-        messages=[{"role": "user", "content": user}],
-        temperature=0,
-    )
+    try:
+        response = client.messages.create(
+            model=model,
+            max_tokens=1024,
+            system=system,
+            messages=[{"role": "user", "content": user}],
+            temperature=0,
+        )
+    except anthropic.BadRequestError as exc:
+        if "reached your specified api usage limits" in str(exc).lower():
+            pytest.skip("Anthropic API usage budget is exhausted")
+        raise
     return response.content[0].text.strip()
 
 

--- a/e2e/test_suite25_media_input.py
+++ b/e2e/test_suite25_media_input.py
@@ -213,6 +213,12 @@ class TestSuite25MediaInput:
 
         result = runtime.run(agent, READ_PROMPT, timeout=TIMEOUT)
 
+        if (
+            result.error
+            and "reached your specified api usage limits" in result.error.lower()
+        ):
+            pytest.skip("Anthropic API usage budget is exhausted")
+
         assert result.status == "COMPLETED", (
             f"no-media run did not complete: status={result.status} "
             f"execution_id={result.execution_id}"


### PR DESCRIPTION
## Summary
- skip the Anthropic-backed workflow judge when the API reports its configured usage limit is exhausted
- skip the Anthropic media counterfactual when the server-backed agent reports the same budget error
- preserve failures for all other API and workflow errors

## Validation
- `python -m compileall -q e2e/test_suite1_basic_validation.py e2e/test_suite25_media_input.py`
- targeted pytest collection for both affected tests
- `git diff --check`

Failure context: https://github.com/conductor-oss/python-sdk/actions/runs/29977126793/job/89314998661#step:12:429