### PR TITLE
Revert "test: skip agent e2e when LLM budget is exhausted"

### DIFF
--- a/e2e/test_suite1_basic_validation.py
+++ b/e2e/test_suite1_basic_validation.py
@@ -360,18 +360,13 @@ def _judge_call_anthropic(model: str, system: str, user: str) -> str:
         )
 
     client = anthropic.Anthropic()  # reads ANTHROPIC_API_KEY from env
-    try:
-        response = client.messages.create(
-            model=model,
-            max_tokens=1024,
-            system=system,
-            messages=[{"role": "user", "content": user}],
-            temperature=0,
-        )
-    except anthropic.BadRequestError as exc:
-        if "reached your specified api usage limits" in str(exc).lower():
-            pytest.skip("Anthropic API usage budget is exhausted")
-        raise
+    response = client.messages.create(
+        model=model,
+        max_tokens=1024,
+        system=system,
+        messages=[{"role": "user", "content": user}],
+        temperature=0,
+    )
     return response.content[0].text.strip()
 
 

--- a/e2e/test_suite25_media_input.py
+++ b/e2e/test_suite25_media_input.py
@@ -213,12 +213,6 @@ class TestSuite25MediaInput:
 
         result = runtime.run(agent, READ_PROMPT, timeout=TIMEOUT)
 
-        if (
-            result.error
-            and "reached your specified api usage limits" in result.error.lower()
-        ):
-            pytest.skip("Anthropic API usage budget is exhausted")
-
         assert result.status == "COMPLETED", (
             f"no-media run did not complete: status={result.status} "
             f"execution_id={result.execution_id}"


### PR DESCRIPTION
## Summary
- revert #445
- allow LLM provider budget exhaustion to fail Agent E2E normally
- require budget issues to be corrected manually instead of skipped by tests

## Validation
- `python -m compileall -q e2e/test_suite1_basic_validation.py e2e/test_suite25_media_input.py`
- `git diff --check origin/main...HEAD`