### PR TITLE
deps: add upper bounds to agent framework and e2e test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,15 +42,23 @@ cloudpickle = ">=2.0"
 # Agent framework integrations — optional, activated via [tool.poetry.extras] below.
 # Floors raised to the versions ConductorAgent's own uv.lock proved mutually compatible
 # (langchain's 0.3.x-floor collided with today's published 1.x line during resolution).
-langchain = { version = ">=1.2.13", optional = true }
-langchain-core = { version = ">=1.2.20", optional = true }
-langchain-openai = { version = ">=1.1.11", optional = true }
-langgraph = { version = ">=1.1.3", optional = true }
-google-adk = { version = ">=1.27.1", optional = true }
-openai = { version = ">=2.28.0", optional = true }
-openai-agents = { version = ">=0.12.2", optional = true }
-anthropic = { version = ">=0.91.0", optional = true }
-claude-code-sdk = { version = ">=0.0.25", optional = true }
+#
+# CEILINGS: every one of these was previously unbounded (">=X" only), so
+# `conductor-python[agents]` accepted any future major of langgraph/openai/anthropic/etc.
+# A breaking upstream release therefore reached users — and the downstream e2e bundle's
+# CI lanes — with no change here, presenting as an SDK or server regression. These are
+# integration surfaces we call directly, so a major bump is exactly where they break.
+# Caps are next-major (next-minor for the 0.x projects, whose minors are breaking by
+# convention). Raise a cap deliberately, with a run of the agent suites behind it.
+langchain = { version = ">=1.2.13,<2", optional = true }
+langchain-core = { version = ">=1.2.20,<2", optional = true }
+langchain-openai = { version = ">=1.1.11,<2", optional = true }
+langgraph = { version = ">=1.1.3,<2", optional = true }
+google-adk = { version = ">=1.27.1,<3", optional = true }
+openai = { version = ">=2.28.0,<3", optional = true }
+openai-agents = { version = ">=0.12.2,<0.13", optional = true }
+anthropic = { version = ">=0.91.0,<0.121", optional = true }
+claude-code-sdk = { version = ">=0.0.25,<0.1", optional = true }
 
 [tool.poetry.extras]
 langchain = ["langchain", "langchain-core", "langchain-openai"]

--- a/scripts/package-e2e-bundle.sh
+++ b/scripts/package-e2e-bundle.sh
@@ -56,13 +56,18 @@ cat > "$STAGE/requirements.txt" <<'EOF'
 conductor-python[agents]==@VERSION@
 
 # Test runner + e2e support deps (mirrors .github/workflows/agent-e2e.yml).
-pytest
-pytest-asyncio
-pytest-xdist
-pytest-rerunfailures
+# Bounded, not bare: these were unpinned, so `pip install -r requirements.txt` inside
+# run.sh resolved to whatever was newest on the day a downstream lane happened to run.
+# A pytest or plugin major could then redden a consumer's gating CI with no change to
+# this bundle — and look like a server regression to whoever triaged it. Floors are the
+# versions this bundle was cut against; ceilings are next-major.
+pytest>=8,<10
+pytest-asyncio>=1,<2
+pytest-xdist>=3,<4
+pytest-rerunfailures>=16,<17
 
 # Live MCP server used by the MCP tool suites.
-mcp-testkit
+mcp-testkit>=1,<2
 EOF
 
 cat > "$STAGE/run.sh" <<'EOF'


### PR DESCRIPTION
Closes #452.

## What

Adds upper bounds to 14 dependency declarations. No new files, no lockfile, nothing to regenerate later.

**`pyproject.toml`** — the `agents` extra, 9 lines:

| Package | From | To |
|---|---|---|
| `langchain` | `>=1.2.13` | `>=1.2.13,<2` |
| `langchain-core` | `>=1.2.20` | `>=1.2.20,<2` |
| `langchain-openai` | `>=1.1.11` | `>=1.1.11,<2` |
| `langgraph` | `>=1.1.3` | `>=1.1.3,<2` |
| `google-adk` | `>=1.27.1` | `>=1.27.1,<3` |
| `openai` | `>=2.28.0` | `>=2.28.0,<3` |
| `openai-agents` | `>=0.12.2` | `>=0.12.2,<0.13` |
| `anthropic` | `>=0.91.0` | `>=0.91.0,<0.121` |
| `claude-code-sdk` | `>=0.0.25` | `>=0.0.25,<0.1` |

**`scripts/package-e2e-bundle.sh`** — the heredoc that writes the bundle's `requirements.txt`, 5 lines: `pytest>=8,<10`, `pytest-asyncio>=1,<2`, `pytest-xdist>=3,<4`, `pytest-rerunfailures>=16,<17`, `mcp-testkit>=1,<2`.

The rest of the diff is comments explaining why the ceilings exist, so they don't get stripped as noise.

## Why

Floor-only declarations meant `conductor-python[agents]` accepted any future **major** of its integration deps, and the bundle's `run.sh` resolves at run time — so a consumer got "whatever is newest today." A breaking upstream release reached users and downstream gating CI with no change here, presenting as an SDK or server regression. See #452 for the full write-up.

Not hypothetical: a langgraph/pydantic interaction with `typing.TypedDict` already fails `test_suite11_langgraph.py::test_messages_state_detection` on Python < 3.12. Only the interpreter pin keeps that green — not a dependency bound.

## Verification

`uv pip compile --universal --python-version 3.12` over the bounded set: **99 packages resolve**, and every capped package lands on the version already installed in a known-good environment — `langgraph 1.2.10`, `anthropic 0.120.2`, `openai-agents 0.12.5`, `claude-code-sdk 0.0.25`, `pytest 9.1.1`, `mcp-testkit 1.0.3`.

So this is a **no-op today**. It only takes effect when someone publishes a new major.

## Draft — two things to settle first

**1. The 0.x policy is the real decision here.** Policy applied is next-major for 1.0+ and next-**minor** for pre-1.0, since 0.x minors are breaking by convention. That makes `anthropic>=0.91.0,<0.121` genuinely protective but tight enough that the next anthropic release needs a bump. The looser alternative is `<1` for all three pre-1.0 deps — one-line change each, much less churn, but close to no protection given their cadence. I picked protection over convenience; happy to flip it. Renovate on this file would make the churn a reviewable PR rather than a chore.

**2. Ceilings have a cost.** They can block a consumer who legitimately needs a newer langgraph, and over-capping is a well-known source of resolution pain in Poetry libraries. `<next-major` is the mainstream compromise, but it is a trade worth someone else's eyes.

**Considered and rejected:** generating a lockfile inside `package-e2e-bundle.sh`. That script documents being static — *"no install, no network — the pinned version does not have to be on PyPI yet, so this can run before the publish job finishes"* — and compiling a lock needs both, breaking release ordering.

## Out of scope, noted in #452

`mcp-testkit` requires Python >= 3.11 while the bundle's `README.md` and `run.sh` advertise 3.10–3.13; compiling at 3.10 is unsatisfiable. Not fixed here.

