### PR TITLE
test only(agents): inherit statefulness into member agents' tool workers

### DIFF
--- a/e2e/test_suite14_stateful_domain.py
+++ b/e2e/test_suite14_stateful_domain.py
@@ -133,8 +133,20 @@ def _get_task_to_domain(execution_id):
 
 
 def _find_tasks_by_type(tasks, task_def_name):
-    """Find tasks matching a taskDefName (or containing it)."""
-    return [t for t in tasks if task_def_name in t.get("taskDefName", "")]
+    """Find tasks matching a taskDefName or referenceTaskName (or containing it).
+
+    referenceTaskName is checked too because compiler-generated system tasks carry
+    their identity there, not in taskDefName: handoff_check is emitted as an INLINE
+    task, so its taskDefName is literally "INLINE" and only the reference name says
+    what it is. Matching taskDefName alone made assertions on those tasks fail even
+    when the tasks existed and had COMPLETED.
+    """
+    return [
+        t
+        for t in tasks
+        if task_def_name in t.get("taskDefName", "")
+        or task_def_name in t.get("referenceTaskName", "")
+    ]
 
 
 def _find_scheduled_tasks(tasks):

--- a/src/conductor/ai/agents/config_serializer.py
+++ b/src/conductor/ai/agents/config_serializer.py
@@ -35,7 +35,7 @@ class AgentConfigSerializer:
         """
         return self._serialize_agent(agent)
 
-    def _serialize_agent(self, agent: "Agent") -> dict:
+    def _serialize_agent(self, agent: "Agent", *, inherited_stateful: bool = False) -> dict:
         from conductor.ai.agents.agent import PromptTemplate
 
         # Skill agents — emit the raw skill config so the server's
@@ -106,14 +106,22 @@ class AgentConfigSerializer:
 
         # Tools
         if agent.tools:
-            agent_stateful = getattr(agent, "stateful", False)
+            # Statefulness belongs to the composite, not only the agent that declares it:
+            # a member of a stateful swarm/team shares the parent's session, so its tools
+            # are stateful too. Reading only `agent.stateful` left member tools unmarked,
+            # which disagreed with how the server routes their tasks. Mirrors the same
+            # inheritance in AgentRuntime._register_workers.
+            agent_stateful = bool(getattr(agent, "stateful", False)) or inherited_stateful
             config["tools"] = [
                 self._serialize_tool(t, agent_stateful=agent_stateful) for t in agent.tools
             ]
 
         # Sub-agents (recursive)
         if agent.agents:
-            config["agents"] = [self._serialize_agent(a) for a in agent.agents]
+            _stateful = bool(getattr(agent, "stateful", False)) or inherited_stateful
+            config["agents"] = [
+                self._serialize_agent(a, inherited_stateful=_stateful) for a in agent.agents
+            ]
 
         # Router
         if agent.router is not None:

--- a/src/conductor/ai/agents/runtime/runtime.py
+++ b/src/conductor/ai/agents/runtime/runtime.py
@@ -1032,7 +1032,12 @@ class AgentRuntime:
         return names
 
     def _register_workers(
-        self, agent: Agent, *, required_workers: Optional[set] = None, domain: Optional[str] = None
+        self,
+        agent: Agent,
+        *,
+        required_workers: Optional[set] = None,
+        domain: Optional[str] = None,
+        inherited_stateful: bool = False,
     ) -> None:
         """Register all workers needed for SDK-side execution.
 
@@ -1084,6 +1089,14 @@ class AgentRuntime:
                 self._register_passthrough_worker(worker)
             return
 
+        # Statefulness is a property of the composite, not just the agent that declares it.
+        # A member of a stateful swarm/team shares the parent's session, so the server
+        # domain-routes ITS tool tasks too. Reading only `agent.stateful` here left member
+        # tool workers polling the default queue while their tasks sat in the domain queue:
+        # pollCount stayed 0, the fork's JOIN never satisfied, and the workflow timed out.
+        # Inherit downward so worker registration matches how the server routes.
+        effective_stateful = bool(getattr(agent, "stateful", False)) or inherited_stateful
+
         # 1. Tools (and tool-level guardrails) — always registered
         if agent.tools:
             tc = ToolRegistry()
@@ -1091,7 +1104,7 @@ class AgentRuntime:
                 agent.tools,
                 agent.name,
                 domain=domain,
-                agent_stateful=getattr(agent, "stateful", False),
+                agent_stateful=effective_stateful,
             )
             for t in agent.tools:
                 from conductor.ai.agents.tool import get_tool_def
@@ -1101,7 +1114,11 @@ class AgentRuntime:
                 if td.tool_type == "agent_tool" and td.config and "agent" in td.config:
                     nested_agent = td.config["agent"]
                     if not getattr(nested_agent, "external", False):
-                        self._register_workers(nested_agent, required_workers=required_workers)
+                        self._register_workers(
+                            nested_agent,
+                            required_workers=required_workers,
+                            inherited_stateful=effective_stateful,
+                        )
                 # Register tool-level guardrail workers
                 tool_guardrails = [
                     g
@@ -1240,7 +1257,12 @@ class AgentRuntime:
                     )
                     self._register_passthrough_worker(worker)
             elif not sub.external:
-                self._register_workers(sub, required_workers=required_workers, domain=domain)
+                self._register_workers(
+                    sub,
+                    required_workers=required_workers,
+                    domain=domain,
+                    inherited_stateful=effective_stateful,
+                )
 
     # ── Worker registration helpers ────────────────────────────────
 


### PR DESCRIPTION
## The bug

A stateful swarm/team shares one session, and the server domain-routes the tasks of everything inside it — `taskToDomain` maps the member agents' tool tasks to the session domain. But `AgentRuntime._register_workers` read `agent.stateful` on the **immediate** agent only.

When a tool hangs off a swarm *member* — and members aren't themselves stateful — its worker registered with `domain=None` while its tasks were queued in the domain queue. Nothing was polling there:

```
ref        : call_W975OtGeIHXtzDxGvI4Q6Zgu_0__1
taskDefName: swarm_tool
domain     : '7203a6c8df354e15b6a30393afe9c72f'
pollCount  : 0
startTime  : 0
```

The enclosing `FORK`'s `JOIN` never satisfied and the workflow ran to `TIMED_OUT`.

## The fix

Propagate statefulness downward so worker registration matches how the server routes:

```python
effective_stateful = bool(getattr(agent, "stateful", False)) or inherited_stateful
```

`_register_workers` takes `inherited_stateful` and passes it to both recursion sites (sub-agents, and nested `agent_tool` agents).

`ConfigSerializer._serialize_agent` had the **same** gap — it dropped `agent_stateful` when recursing into sub-agents, so member tools were never marked `stateful` in the config sent to the server. Fixed the same way, so both sides agree. This one wasn't strictly required to make the test pass (the server derives routing from the swarm), but leaving the two halves disagreeing is how this bug happened in the first place.

## Also: an e2e helper that was hiding it

`_find_tasks_by_type` matched only `taskDefName`. Compiler-generated system tasks carry their identity in `referenceTaskName` — `handoff_check` is emitted as an `INLINE` task, so its `taskDefName` is literally `"INLINE"`:

```
ref=e2e_s14_stateful_swarm_handoff_check__1  taskDefName='INLINE'  status=COMPLETED
```

`assert handoff_tasks` therefore failed with **20 `handoff_check` tasks present and COMPLETED**. Now matches either field.

## Verification

Against a conductor-oss server built from `main`, isolating each change:

| Configuration | Result |
|---|---|
| stock SDK | **FAILED** — workflow `RUNNING`, 304s |
| runtime fix only | **FAILED** — workflow `COMPLETED`, fails `handoff_check` assert |
| runtime + test fix | **PASSED** — 118s |
| + serializer fix | **PASSED** — whole `suite14` green, 6/6 |
| full mainline e2e | **136 passed, 1 failed, 7 skipped, 1 xfailed** |

The middle row is the useful one: it isolates the two bugs and shows the runtime fix alone is enough to get the workflow completing.

The one remaining failure is `test_get_after_delete_returns_none` — an unrelated scheduler 404-vs-`None` contract mismatch, present before this change.

`test_non_stateful_no_domain` is the guard against **over**-propagation, and it still passes — statefulness isn't leaking into agents that never declared it. That's why I ran the whole file rather than the one test.

## Draft, because two things want a second opinion

1. **Is `stateful` intended to be inherited?** I've assumed yes — a member of a stateful composite shares its session, so its tools are stateful in every sense that matters to routing. If the intended semantics are "only the declaring agent", then the fix belongs on the server side instead (don't domain-route tools that aren't marked stateful), and this PR is wrong.
2. **The serializer half changes what's sent to the server**, so it can affect compilation. Suite14 is green, but I haven't reasoned through every other topology that flag reaches.

## Notes

- Found while investigating why conductor-oss/conductor#1363 was listed as a known failure in that repo's CI. The root cause recorded there was wrong — it blamed missing `*_transfer_to_*` task defs; those register fine and the handoff itself succeeds. Corrected in conductor-oss/conductor@63c0715b7.
- Timing correction for anyone reading that issue: a single attempt is ~304s (the SDK's 300s wait), not ~908s. The larger figure was three attempts under `conftest`'s unconditional `flaky(reruns=2)`.

