### PR TITLE
Resolve #426: WaitTask base class sets wrong inputParameter key 'wait_until' instead of 'until'

### DIFF
--- a/src/conductor/client/workflow/task/wait_task.py
+++ b/src/conductor/client/workflow/task/wait_task.py
@@ -22,7 +22,7 @@ class WaitTask(TaskInterface, ABC):
             raise Exception("both wait_until and wait_for_seconds are provided.  ONLY one is allowed")
         if wait_until:
             self.input_parameters = {
-                "wait_until": wait_until
+                "until": wait_until
             }
         if wait_for_seconds:
             self.input_parameters = {

--- a/tests/unit/workflow/test_wait_task.py
+++ b/tests/unit/workflow/test_wait_task.py
@@ -1,0 +1,34 @@
+import unittest
+
+from conductor.client.workflow.task.wait_task import (
+    WaitForDurationTask,
+    WaitTask,
+    WaitUntilTask,
+)
+
+
+class TestWaitTask(unittest.TestCase):
+    def test_wait_until_uses_server_recognized_until_key(self):
+        task = WaitTask("wait_until", wait_until="2026-08-05 12:00 UTC")
+
+        self.assertEqual(task.input_parameters, {"until": "2026-08-05 12:00 UTC"})
+        self.assertNotIn("wait_until", task.input_parameters)
+
+    def test_wait_for_seconds_uses_duration_key(self):
+        task = WaitTask("wait_for_seconds", wait_for_seconds=60)
+
+        self.assertEqual(task.input_parameters, {"duration": "60s"})
+
+    def test_wait_for_duration_task_uses_duration_key(self):
+        task = WaitForDurationTask("wait_for_duration", duration_time_seconds=30)
+
+        self.assertEqual(task.input_parameters, {"duration": "30s"})
+
+    def test_wait_until_task_uses_until_key(self):
+        task = WaitUntilTask("wait_until_task", date_time="2026-08-05 12:00 UTC")
+
+        self.assertEqual(task.input_parameters, {"until": "2026-08-05 12:00 UTC"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #426

## Summary
Correct the direct `WaitTask(wait_until=...)` serialization key and add a focused unit regression test. No server integration or subclass changes are needed.

## Subtasks
- **fix-wait-task-until-key**: Change `WaitTask.__init__` to store `wait_until` under the server-recognized `until` input key. Add unit coverage asserting the direct constructor emits `{"until": ...}` without `wait_until`, while preserving existing duration behavior and the already-correct `WaitUntilTask` behavior.

## Verification
- Verified: false
- Findings:
- Complete: direct `WaitTask(wait_until=...)` now serializes as `{"until": ...}`, matching the existing server-recognized key used by `WaitUntilTask`.
- Focused regression coverage was added in `tests/unit/workflow/test_wait_task.py`, including an assertion that the obsolete `wait_until` key is absent. No server integration or subclass implementation changes were introduced.
- Verification is unavailable from the supplied result: the single-program invocation of `coverage` failed with `FileNotFoundError` before any tests ran. This is an unavailable/malformed test command in this environment, not evidence of a project-code failure.

---
_Automated resolution by the Conductor coding harness (code_parallel)._